### PR TITLE
Added null value operation handling for currencies

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -304,7 +304,10 @@ function performOperations(v, arg, operation) {
         result[key] = operationOnItem(v[key],arg[key], operation);
       })
     } else {
-      result = getDefaultNumericResult(result, 0, 0, operation)
+      // Assumes that only one numeric key to be used to calculate default value
+      const defaulArg1Value = numberKeysOfV.length > 0 ? v[`${numberKeysOfV[0]}`] : 0
+      const defaulArg2Value = numberKeysOfArg.length > 0 ? arg[`${numberKeysOfArg[0]}`] : 0
+      result = getDefaultNumericResult(result, defaulArg1Value, defaulArg2Value, operation)
     }
     return result;
   } else if (typeof(v) === "number" && isObject(arg)) {

--- a/filters.js
+++ b/filters.js
@@ -303,8 +303,8 @@ function performOperations(v, arg, operation) {
     const numberKeysOfArg = filterNumericKeysFromObject(arg);
     const numberKeysOfV = filterNumericKeysFromObject(v);
     const commonNumericKeys = numberKeysOfV.filter(elem => numberKeysOfArg.indexOf(elem) !== -1)
-    // If numeric keys are present for object, update object all keys with op value with number
-    // otherwise get default result value sending both value as 0
+    // If common numeric keys are present for objects, update all of them in result with op value 
+    // otherwise get default result sending both value as 0
 
     if(commonNumericKeys.length > 0) {
       numberKeysOfArg.forEach(key => {
@@ -320,8 +320,8 @@ function performOperations(v, arg, operation) {
   } else if (typeof(v) === "number" && isObject(arg)) {
     let result = getObjectValues(arg)
     const numberKeys = filterNumericKeysFromObject(arg);
-    // If numeric keys are present for object, update object all keys with op value with number
-    // otherwise get default result value sending arg's value as 0
+    // If numeric keys are present for arg, update all of them in result with op value with number
+    // otherwise get default result sending arg's value as 0
     if(numberKeys.length > 0) {
       numberKeys.forEach(key => {
         result[key] = operationOnItem(v, arg[key], operation);
@@ -333,8 +333,8 @@ function performOperations(v, arg, operation) {
   } else if (isObject(v) && typeof(arg) === "number") {
     let result = getObjectValues(v)
     const numberKeys = filterNumericKeysFromObject(v);
-    // If numeric keys are present for object, update object all keys with op value with number
-    // otherwise get default result value sending v's value as 0
+    // If numeric keys are present for v, update all of them in result with op value with number
+    // otherwise get default result sending v's value as 0
     if(numberKeys.length > 0) {
       numberKeys.forEach(key => {
         result[key] = operationOnItem(v[key], arg, operation)

--- a/filters.js
+++ b/filters.js
@@ -106,6 +106,10 @@ var filters = {
 };
 
 const CF_DATE_FORMAT = "YYYY-MM-DD"
+/**
+ * MAP for numeric key for a CF object
+ * For ex: Cf currency object has "value" key which holds the numeric info
+ */
 const CF_OBJECT_NUMERIC_KEY_MAP = {
   CURRENCY: "value"
 }
@@ -251,7 +255,7 @@ function isBothArgsValidDateOrDateString(v, arg) {
 
 /**
  * Gets default value for Cf objects operations in case numeric keys absent
- * Currently only supports currency objects
+ * Currently only supports Cf currency objects
  * @param {*} result 
  * @param {*} v 
  * @param {*} arg 
@@ -299,6 +303,9 @@ function performOperations(v, arg, operation) {
     const numberKeysOfArg = filterNumericKeysFromObject(arg);
     const numberKeysOfV = filterNumericKeysFromObject(v);
     const commonNumericKeys = numberKeysOfV.filter(elem => numberKeysOfArg.indexOf(elem) !== -1)
+    // If numeric keys are present for object, update object all keys with op value with number
+    // otherwise get default result value sending both value as 0
+
     if(commonNumericKeys.length > 0) {
       numberKeysOfArg.forEach(key => {
         result[key] = operationOnItem(v[key],arg[key], operation);
@@ -313,6 +320,8 @@ function performOperations(v, arg, operation) {
   } else if (typeof(v) === "number" && isObject(arg)) {
     let result = getObjectValues(arg)
     const numberKeys = filterNumericKeysFromObject(arg);
+    // If numeric keys are present for object, update object all keys with op value with number
+    // otherwise get default result value sending arg's value as 0
     if(numberKeys.length > 0) {
       numberKeys.forEach(key => {
         result[key] = operationOnItem(v, arg[key], operation);
@@ -324,6 +333,8 @@ function performOperations(v, arg, operation) {
   } else if (isObject(v) && typeof(arg) === "number") {
     let result = getObjectValues(v)
     const numberKeys = filterNumericKeysFromObject(v);
+    // If numeric keys are present for object, update object all keys with op value with number
+    // otherwise get default result value sending v's value as 0
     if(numberKeys.length > 0) {
       numberKeys.forEach(key => {
         result[key] = operationOnItem(v[key], arg, operation)

--- a/test/filters.js
+++ b/test/filters.js
@@ -176,6 +176,24 @@ describe('filters', function () {
       const dst = {value: 1.094, type: "USD"};
       return test('{{ currency_decimal | divided_by: 12.3 }}', JSON.stringify(dst))
     })
+    // Null variable tests for currency
+    it('should support currency handling with one currency variable with value null in middle', () => {
+      const dst = {value: 0, type: "INR"};
+      return test('{{ currency_thousand | divided_by: currency_val_null | divided_by: currency_hundred }}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null at last', () => {
+      // It is null because last variable is null
+      const dst = {value: null, type: "INR"};
+      return test('{{ currency_thousand | divided_by: currency_hundred | divided_by: currency_val_null}}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null and a number', () => {
+      const dst = {value: 0, type: "INR"};
+      return test('{{ currency_val_null | divided_by: 2 }}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null, a number and another currency', () => {
+      const dst = {value: 0, type: "INR"};
+      return test('{{ 2 | divided_by: currency_val_null | divided_by: currency_thousand}}', JSON.stringify(dst))
+    })
     it('should convert string to number', () => test('{{"5" | divided_by: "3"}}', '1.667'))
     /* Test for null argument */
     it('should return "0" for 24,null', () => test('{{ 24 | divided_by: null }}', "0"))
@@ -272,6 +290,23 @@ describe('filters', function () {
     it('should support currency with decimals minus number with decimal', () => {
       const dst = {value: 1.156, type: "USD"};
       return test('{{ currency_decimal | minus: 12.3 }}', JSON.stringify(dst))
+    })
+    // Null variable tests for currency
+    it('should support currency handling with one currency variable with value null in middle', () => {
+      const dst = {value: 90, type: "INR"};
+      return test('{{ currency_hundred | minus: currency_val_null | minus: currency_ten }}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null at last', () => {
+      const dst = {value: 90, type: "INR"};
+      return test('{{ currency_hundred | minus: currency_ten | minus: currency_val_null}}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null and a number', () => {
+      const dst = {value: -2, type: "INR"};
+      return test('{{ currency_val_null | minus: 2 }}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null, a number and another currency', () => {
+      const dst = {value: -998, type: "INR"};
+      return test('{{ 2 | minus: currency_val_null | minus: currency_thousand}}', JSON.stringify(dst))
     })
     it('should convert first arg as number', () => test('{{ "4" | minus: 1 }}', '3'))
     it('should convert both args as number', () => test('{{ "4" | minus: "1" }}', '3'))
@@ -440,6 +475,23 @@ describe('filters', function () {
     it('should support currency with decimals add number with decimal', () => {
       const dst = {value: 25.756, type: "USD"};
       return test('{{ currency_decimal | plus: 12.3 }}', JSON.stringify(dst))
+    })
+    // Null variable tests for currency
+    it('should support currency handling with one currency variable with value null in middle', () => {
+      const dst = {value: 1100, type: "INR"};
+      return test('{{ currency_thousand | plus: currency_val_null | plus: currency_hundred }}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null at last', () => {
+      const dst = {value: 1100, type: "INR"};
+      return test('{{ currency_thousand | plus: currency_hundred | plus: currency_val_null}}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null and a number', () => {
+      const dst = {value: 2, type: "INR"};
+      return test('{{ currency_val_null | plus: 2 }}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null, a number and another currency', () => {
+      const dst = {value: 1002, type: "INR"};
+      return test('{{ 2 | plus: currency_val_null | plus: currency_thousand}}', JSON.stringify(dst))
     })
     /* Tests for date and duration */
     it('should add 10 weeks to current date', () => {
@@ -635,7 +687,24 @@ describe('filters', function () {
     it('should return "0" for 24,null', () => test('{{ 24 | times: null }}', "0"))
     it('should return "0" for null, 24', () => test('{{ null | times: 24 }}', "0"))
     it('should return "0" for variable null, 24', () => test('{{ variable_null | times: 24 }}', "0"))
-    it('should return "0" for variable_null, variable null', () => test('{{ variable_null | times: variable_null }}', "null"))
+    it('should return "null" for variable_null, variable null', () => test('{{ variable_null | times: variable_null }}', "null"))
+    // Null variable tests for currency
+    it('should support currency handling with one currency variable with value null in middle', () => {
+      const dst = {value: 0, type: "INR"};
+      return test('{{ currency_hundred | times: currency_val_null | times: currency_ten }}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null at last', () => {
+      const dst = {value: 0, type: "INR"};
+      return test('{{ currency_hundred | times: currency_ten | times: currency_val_null}}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null and a number', () => {
+      const dst = {value: 0, type: "INR"};
+      return test('{{ currency_val_null | times: 2 }}', JSON.stringify(dst))
+    })
+    it('should support currency handling with one currency variable with value null, a number and another currency', () => {
+      const dst = {value: 0, type: "INR"};
+      return test('{{ 2 | times: currency_val_null | times: currency_thousand}}', JSON.stringify(dst))
+    })
   })
 
   describe('truncate', function () {


### PR DESCRIPTION
Subtask of https://gitlab.dev.spotdraft.com/sd/untriaged-bugs/issues/648

- Handles a specific case in division where denominator is zero
- Adds null handling for all currency object related operations {{value: null, type: "INR"}}
- Adds tests for multiple operations having currency.value as null 

We have not made any changes in currency * null and it still returns null. Because updating object and null operations will also affect duration and date calculations.
