### PR TITLE
add new tag - parseAssign

### DIFF
--- a/tags/index.js
+++ b/tags/index.js
@@ -14,4 +14,5 @@ module.exports = function (engine) {
   require('./raw.js')(engine)
   require('./tablerow.js')(engine)
   require('./unless.js')(engine)
+  require('./parseAssign.js')(engine)
 }

--- a/tags/parseAssign.js
+++ b/tags/parseAssign.js
@@ -1,0 +1,50 @@
+const Liquid = require("..");
+const lexical = Liquid.lexical;
+const Promise = require("any-promise");
+const re = new RegExp(`(${lexical.identifier.source})\\s*=(.*)`);
+const assert = require("../src/util/assert.js");
+
+function parseFromString(objStr) {
+  const jsonStr = `{"val": ${objStr}}`;
+  return JSON.parse(jsonStr).val;
+}
+
+/**
+ * This tag can be used to assign object and arrays to variables directly
+ * in liquid code. This modifies the scope to add the parsed object or array
+ * against the provided key.
+ *
+ * Usage:
+ * {% parseAssign arr = "[1,2,3]" %}
+ * {% parseAssign obj = '{"prop1": prop1Val, "prop2": prop2Val}' %}
+ *
+ * Result:
+ * Scope now has
+ * {
+ *  ...,
+ *  arr: [1,2,3],
+ *  obj: {
+ *    prop1: prop1Val,
+ *    prop2: prop2Val
+ *  }
+ * }
+ *
+ * Note: The value being assigned should be valid JSON.
+ * Invalid JSON will results in exception being thrown.
+ */
+module.exports = function (liquid) {
+  liquid.registerTag("parseAssign", {
+    parse: function (token) {
+      var match = token.args.match(re);
+      assert(match, `illegal token ${token.raw}`);
+      this.key = match[1];
+      this.value = match[2];
+    },
+    render: function (scope) {
+      const value = liquid.evalValue(this.value, scope);
+      const actualValue = parseFromString(value);
+      scope.set(this.key, actualValue);
+      return Promise.resolve("");
+    },
+  });
+};

--- a/test/tags/parseAssign.js
+++ b/test/tags/parseAssign.js
@@ -1,0 +1,55 @@
+const Liquid = require("../..");
+const chai = require("chai");
+const expect = chai.expect;
+chai.use(require("chai-as-promised"));
+
+describe.only("tags/parseAssign", function () {
+  const liquid = Liquid();
+  it("should throw when variable expression illegal", function () {
+    const src = "{% parseAssign / %}";
+    const ctx = {};
+    return expect(liquid.parseAndRender(src, ctx)).to.be.rejectedWith(
+      /illegal/
+    );
+  });
+
+  it("should throw when variable value is illegal JSON", function () {
+    const src = `{% parseAssign foo = '{prop: 123}' %}`;
+    const ctx = {};
+    return expect(liquid.parseAndRender(src, ctx)).to.be.rejected;
+  });
+
+  it("should parseAssign string", function () {
+    const ctx = {};
+    const src = `{% parseAssign foo='"bar"' -%}{{foo}}`;
+    return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal("bar");
+  });
+
+  it("should parseAssign number", function () {
+    const ctx = {};
+    const src = "{% parseAssign foo=35 -%}{{foo}}";
+    return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal("35");
+  });
+  it("should parseAssign boolean", function () {
+    const ctx = {};
+    const src = "{% parseAssign foo=false -%}{{foo}}";
+    return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal("false");
+  });
+
+  it("should parseAssign array", function () {
+    const ctx = {};
+    const src =
+      '{% parseAssign foo="[100,200,300]" -%}{{foo[0]}}__{{foo[1]}}__{{foo[2]}}';
+    return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(
+      "100__200__300"
+    );
+  });
+
+  it("should parseAssign object", function () {
+    const ctx = {};
+    const src = `{% parseAssign foo='{"x": 100, "y": "bar"}' -%}{{foo.x}}__{{foo.y}}`;
+    return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(
+      "100__bar"
+    );
+  });
+});

--- a/test/tags/parseAssign.js
+++ b/test/tags/parseAssign.js
@@ -3,7 +3,7 @@ const chai = require("chai");
 const expect = chai.expect;
 chai.use(require("chai-as-promised"));
 
-describe.only("tags/parseAssign", function () {
+describe("tags/parseAssign", function () {
   const liquid = Liquid();
   it("should throw when variable expression illegal", function () {
     const src = "{% parseAssign / %}";


### PR DESCRIPTION
This MR adds a new tag to our fork of LiquidJS. THE TAG IS called `parseAssign`.

It converts array or objects passed as a string to their JS object value and assigns these values to the key provided. This key is then appended to the Scope.

```
{% parseAssign arr = "[1,2,3]" %}
{% parseAssign obj = '{"prop1": prop1Val, "prop2": prop2Val}' %}
```

Result:
Scope now has
```
{
    ...,
    arr: [1,2,3],
    obj: {
        prop1: prop1Val,
        prop2: prop2Val
    }
}
```

**Note**: The value being assigned should be valid JSON. Invalid JSON will results in exception being thrown.

**Passes tests**
<img width="519" alt="Screenshot 2022-04-13 at 5 51 26 PM" src="https://user-images.githubusercontent.com/8885566/163181514-2dbb68da-283c-4d5a-b470-485f3e5a4d79.png">
