### PR TITLE
support comparison of commonform data types directly using operators

### DIFF
--- a/sd-custom/custom-operator/equals.js
+++ b/sd-custom/custom-operator/equals.js
@@ -1,0 +1,126 @@
+const moment = require("moment");
+const { getType, SD_CUSTOM_TYPES } = require("../type-assert");
+
+function dateEquals(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.date) {
+    return false;
+  }
+
+  return moment.utc(l).isSame(moment.utc(r));
+}
+
+function durationEquals(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.duration) {
+    return false;
+  }
+
+  return l.days === r.days;
+}
+
+function currencyEquals(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.currency) {
+    return false;
+  }
+
+  return l.value === r.value && l.type === r.type;
+}
+
+function phoneNumberEquals(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.phoneNumber) {
+    return false;
+  }
+
+  return (
+    l.number === r.number &&
+    l.code === r.code &&
+    l.country_code === r.country_code
+  );
+}
+
+/**
+ * Sorts the array using default JS sorting method.
+ * Loops through the sorted arrays and checks whether they have same items at same index.
+ * Empty array is considered equal to another empty array
+ */
+function arrayEquals(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.array) {
+    return false;
+  }
+
+  if (l.length !== r.length) {
+    return false;
+  }
+
+  // Empty array should be equal to another empty array
+  if (l.length === 0) {
+    return true;
+  }
+
+  const sortedL = [...l].sort();
+  const sortedR = [...r].sort();
+
+  return sortedL.every((val, idx) => {
+    return val === sortedR[idx];
+  });
+}
+
+function equals(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  switch (lType) {
+    case SD_CUSTOM_TYPES.array:
+      return arrayEquals(l, r);
+    case SD_CUSTOM_TYPES.duration:
+      return durationEquals(l, r);
+    case SD_CUSTOM_TYPES.date:
+      return dateEquals(l, r);
+    case SD_CUSTOM_TYPES.currency:
+      return currencyEquals(l, r);
+    case SD_CUSTOM_TYPES.phoneNumber:
+      return phoneNumberEquals(l, r);
+    default:
+      return l === r;
+  }
+}
+
+module.exports = equals;

--- a/sd-custom/custom-operator/equals.js
+++ b/sd-custom/custom-operator/equals.js
@@ -58,11 +58,7 @@ function phoneNumberEquals(l, r) {
     return false;
   }
 
-  return (
-    l.number === r.number &&
-    l.code === r.code &&
-    l.country_code === r.country_code
-  );
+  return l.number === r.number && l.code === r.code;
 }
 
 /**

--- a/sd-custom/custom-operator/greater-or-equal.js
+++ b/sd-custom/custom-operator/greater-or-equal.js
@@ -1,0 +1,68 @@
+const moment = require("moment");
+const { getType, SD_CUSTOM_TYPES } = require("../type-assert");
+
+function dateGreaterThanOrEqual(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.date) {
+    return false;
+  }
+  return moment.utc(l).isSameOrAfter(moment.utc(r));
+}
+
+function durationGreaterThanOrEqual(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.duration) {
+    return false;
+  }
+
+  return l.days >= r.days;
+}
+
+function currencyGreaterThanOrEqual(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.currency) {
+    return false;
+  }
+
+  return l.value >= r.value && l.type === r.type;
+}
+
+function greaterThanOrEqual(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  switch (lType) {
+    case SD_CUSTOM_TYPES.duration:
+      return durationGreaterThanOrEqual(l, r);
+    case SD_CUSTOM_TYPES.currency:
+      return currencyGreaterThanOrEqual(l, r);
+    case SD_CUSTOM_TYPES.date:
+      return dateGreaterThanOrEqual(l, r);
+    default:
+      return l >= r;
+  }
+}
+
+module.exports = greaterThanOrEqual;

--- a/sd-custom/custom-operator/greater.js
+++ b/sd-custom/custom-operator/greater.js
@@ -1,0 +1,68 @@
+const moment = require("moment");
+const { getType, SD_CUSTOM_TYPES } = require("../type-assert");
+
+function dateGreaterThan(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.date) {
+    return false;
+  }
+  return moment.utc(l).isAfter(moment.utc(r));
+}
+
+function durationGreaterThan(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.duration) {
+    return false;
+  }
+
+  return l.days > r.days;
+}
+
+function currencyGreaterThan(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.currency) {
+    return false;
+  }
+
+  return l.value > r.value && l.type === r.type;
+}
+
+function greaterThan(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  switch (lType) {
+    case SD_CUSTOM_TYPES.duration:
+      return durationGreaterThan(l, r);
+    case SD_CUSTOM_TYPES.currency:
+      return currencyGreaterThan(l, r);
+    case SD_CUSTOM_TYPES.date:
+      return dateGreaterThan(l, r);
+    default:
+      return l > r;
+  }
+}
+
+module.exports = greaterThan;

--- a/sd-custom/custom-operator/smaller-or-equal.js
+++ b/sd-custom/custom-operator/smaller-or-equal.js
@@ -1,0 +1,68 @@
+const moment = require("moment");
+const { getType, SD_CUSTOM_TYPES } = require("../type-assert");
+
+function dateSmallerThanOrEqual(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.date) {
+    return false;
+  }
+  return moment.utc(l).isSameOrBefore(moment.utc(r));
+}
+
+function durationSmallerThanOrEqual(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.duration) {
+    return false;
+  }
+
+  return l.days <= r.days;
+}
+
+function currencySmallerThanOrEqual(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.currency) {
+    return false;
+  }
+
+  return l.value <= r.value && l.type === r.type;
+}
+
+function smallerThanOrEqual(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  switch (lType) {
+    case SD_CUSTOM_TYPES.duration:
+      return durationSmallerThanOrEqual(l, r);
+    case SD_CUSTOM_TYPES.currency:
+      return currencySmallerThanOrEqual(l, r);
+    case SD_CUSTOM_TYPES.date:
+      return dateSmallerThanOrEqual(l, r);
+    default:
+      return l <= r;
+  }
+}
+
+module.exports = smallerThanOrEqual;

--- a/sd-custom/custom-operator/smaller.js
+++ b/sd-custom/custom-operator/smaller.js
@@ -1,0 +1,68 @@
+const moment = require("moment");
+const { getType, SD_CUSTOM_TYPES } = require("../type-assert");
+
+function dateSmaller(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.date) {
+    return false;
+  }
+  return moment.utc(l).isBefore(moment.utc(r));
+}
+
+function durationSmaller(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.duration) {
+    return false;
+  }
+
+  return l.days < r.days;
+}
+
+function currencySmaller(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  if (lType !== SD_CUSTOM_TYPES.currency) {
+    return false;
+  }
+
+  return l.value < r.value && l.type === r.type;
+}
+
+function smaller(l, r) {
+  const lType = getType(l);
+  const rType = getType(r);
+
+  if (lType !== rType) {
+    return false;
+  }
+
+  switch (lType) {
+    case SD_CUSTOM_TYPES.duration:
+      return durationSmaller(l, r);
+    case SD_CUSTOM_TYPES.currency:
+      return currencySmaller(l, r);
+    case SD_CUSTOM_TYPES.date:
+      return dateSmaller(l, r);
+    default:
+      return l < r;
+  }
+}
+
+module.exports = smaller;

--- a/sd-custom/type-assert.js
+++ b/sd-custom/type-assert.js
@@ -1,0 +1,105 @@
+const moment = require("moment");
+
+const CF_DATE_FORMAT = "YYYY-MM-DD";
+
+const SD_CUSTOM_TYPES = {
+  date: "date",
+  string: "string",
+  number: "number",
+  boolean: "boolean",
+  array: "array",
+  duration: "duration",
+  currency: "currency",
+  phoneNumber: "phone-number",
+};
+
+function isValidDateString(dateString) {
+  return (
+    typeof dateString === "string" &&
+    (moment(dateString, moment.ISO_8601, true).isValid() ||
+      moment(dateString, CF_DATE_FORMAT, true).isValid())
+  );
+}
+
+function isDurationObject(durationObj) {
+  if (!durationObj || !durationObj.hasOwnProperty) {
+    return false;
+  }
+
+  const durationProps = ["value", "type", "days"];
+  if (durationProps.some((prop) => !durationObj.hasOwnProperty(prop))) {
+    return false;
+  }
+
+  const units = ["DAYS", "WEEKS", "MONTHS", "YEARS"];
+  if (units.indexOf(durationObj.type) != -1) {
+    return true;
+  }
+
+  return false;
+}
+
+function isCurrencyObject(currencyObj) {
+  if (!currencyObj || !currencyObj.hasOwnProperty) {
+    return false;
+  }
+
+  const durationProps = ["value", "type"];
+  if (durationProps.some((prop) => !currencyObj.hasOwnProperty(prop))) {
+    return false;
+  }
+
+  return true;
+}
+
+function isValidPhoneNumber(phoneNumberObj) {
+  if (!phoneNumberObj || !phoneNumberObj.hasOwnProperty) {
+    return false;
+  }
+
+  const phoneNumberProps = ["number", "code", "country_code"];
+  if (phoneNumberProps.some((prop) => !phoneNumberObj.hasOwnProperty(prop))) {
+    return false;
+  }
+
+  return true;
+}
+
+function getType(v) {
+  // This check should be before string check as date strings are also valid strings
+  if (isValidDateString(v)) {
+    return SD_CUSTOM_TYPES.date;
+  }
+
+  if (typeof v === "string") {
+    return SD_CUSTOM_TYPES.string;
+  }
+
+  if (typeof v === "number" && !Number.isNaN(v)) {
+    return SD_CUSTOM_TYPES.number;
+  }
+
+  if (typeof v === "boolean") {
+    return SD_CUSTOM_TYPES.boolean;
+  }
+
+  if (Array.isArray(v)) {
+    return SD_CUSTOM_TYPES.array;
+  }
+
+  // It is important to have Duration check before currency check because properties of Duration
+  // are a superset of Currency. So a duration object will match currency check.
+  if (isDurationObject(v)) {
+    return SD_CUSTOM_TYPES.duration;
+  }
+
+  if (isCurrencyObject(v)) {
+    return SD_CUSTOM_TYPES.currency;
+  }
+
+  if (isValidPhoneNumber(v)) {
+    return SD_CUSTOM_TYPES.phoneNumber;
+  }
+}
+
+module.exports = { getType, SD_CUSTOM_TYPES };

--- a/sd-custom/type-assert.js
+++ b/sd-custom/type-assert.js
@@ -57,7 +57,7 @@ function isValidPhoneNumber(phoneNumberObj) {
     return false;
   }
 
-  const phoneNumberProps = ["number", "code", "country_code"];
+  const phoneNumberProps = ["number", "code"];
   if (phoneNumberProps.some((prop) => !phoneNumberObj.hasOwnProperty(prop))) {
     return false;
   }

--- a/src/operators.js
+++ b/src/operators.js
@@ -1,17 +1,23 @@
+const equals = require("../sd-custom/custom-operator/equals");
+const greaterThan = require("../sd-custom/custom-operator/greater");
+const smallerThan = require("../sd-custom/custom-operator/smaller");
+const greaterThanOrEquals = require("../sd-custom/custom-operator/greater-or-equal");
+const smallerThanOrEquals = require("../sd-custom/custom-operator/smaller-or-equal");
+
 module.exports = function (isTruthy) {
   return {
-    '==': (l, r) => l === r,
-    '!=': (l, r) => l !== r,
-    '>': (l, r) => l !== null && r !== null && l > r,
-    '<': (l, r) => l !== null && r !== null && l < r,
-    '>=': (l, r) => l !== null && r !== null && l >= r,
-    '<=': (l, r) => l !== null && r !== null && l <= r,
-    'contains': (l, r) => {
-      if (!l) return false
-      if (typeof l.indexOf !== 'function') return false
-      return l.indexOf(r) > -1
+    "==": (l, r) => equals(l, r),
+    "!=": (l, r) => !equals(l, r),
+    ">": (l, r) => l !== null && r !== null && greaterThan(l, r),
+    "<": (l, r) => l !== null && r !== null && smallerThan(l, r),
+    ">=": (l, r) => l !== null && r !== null && greaterThanOrEquals(l, r),
+    "<=": (l, r) => l !== null && r !== null && smallerThanOrEquals(l, r),
+    contains: (l, r) => {
+      if (!l) return false;
+      if (typeof l.indexOf !== "function") return false;
+      return l.indexOf(r) > -1;
     },
-    'and': (l, r) => isTruthy(l) && isTruthy(r),
-    'or': (l, r) => isTruthy(l) || isTruthy(r)
-  }
-}
+    and: (l, r) => isTruthy(l) && isTruthy(r),
+    or: (l, r) => isTruthy(l) || isTruthy(r),
+  };
+};

--- a/test/sd-custom/custom-operator/custom-operators.js
+++ b/test/sd-custom/custom-operator/custom-operators.js
@@ -1,0 +1,573 @@
+const Liquid = require("../../..");
+const chai = require("chai");
+const expect = chai.expect;
+chai.use(require("chai-as-promised"));
+
+function getLiquidText(conditionStr) {
+  return `{% if ${conditionStr} -%}true{% else -%}false{% endif %}`;
+}
+
+function getCtx() {
+  return {
+    lStr: "left",
+    rStr: "right",
+    lNum: 10,
+    rNum: 100,
+    lBool: false,
+    rBool: true,
+    lDate: "2000-01-01",
+    rDate: "2001-01-01",
+    lDur: {
+      value: 1,
+      type: "YEARS",
+      days: 365,
+    },
+    rDur: {
+      value: 2,
+      type: "YEARS",
+      days: 2 * 365,
+    },
+    lCurr: {
+      value: 100,
+      type: "USD",
+    },
+    rCurr: {
+      value: 200,
+      type: "USD",
+    },
+    lPhone: {
+      number: "9876543210",
+      code: "+1",
+      country_code: "+1",
+    },
+    rPhone: {
+      number: "1111111112",
+      code: "+1",
+      country_code: "+1",
+    },
+  };
+}
+
+const TRUE = "true";
+const FALSE = "false";
+
+describe("custom operators", () => {
+  let ctx;
+  let liquid;
+  beforeEach(() => {
+    ctx = getCtx();
+    liquid = Liquid();
+  });
+
+  describe("custom operators/==", () => {
+    it("should eval identical strings", function () {
+      const src = getLiquidText("lStr == lStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical strings", function () {
+      const src = getLiquidText("lStr == rStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical numbers", function () {
+      const src = getLiquidText("lNum == lNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical numbers", function () {
+      const src = getLiquidText("lNum == rNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical booleans", function () {
+      const src = getLiquidText("lBool == lBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical booleans", function () {
+      const src = getLiquidText("lBool == rBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical dates", function () {
+      const src = getLiquidText("lDate == lDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical dates", function () {
+      const src = getLiquidText("lDate == rDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical duration", function () {
+      const src = getLiquidText("lDur == lDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical duration", function () {
+      const src = getLiquidText("lDur == rDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical currency", function () {
+      const src = getLiquidText("lCurr == lCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical currency", function () {
+      const src = getLiquidText("lCurr == rCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical phone number", function () {
+      const src = getLiquidText("lPhone == lPhone");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical phone number", function () {
+      const src = getLiquidText("lPhone == rPhone");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+  });
+
+  describe("custom operators/!=", () => {
+    it("should eval identical strings", function () {
+      const src = getLiquidText("lStr != lStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical strings", function () {
+      const src = getLiquidText("lStr != rStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical numbers", function () {
+      const src = getLiquidText("lNum != lNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical numbers", function () {
+      const src = getLiquidText("lNum != rNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical booleans", function () {
+      const src = getLiquidText("lBool != lBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical booleans", function () {
+      const src = getLiquidText("lBool != rBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical dates", function () {
+      const src = getLiquidText("lDate != lDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical dates", function () {
+      const src = getLiquidText("lDate != rDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical duration", function () {
+      const src = getLiquidText("lDur != lDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical duration", function () {
+      const src = getLiquidText("lDur != rDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical currency", function () {
+      const src = getLiquidText("lCurr != lCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical currency", function () {
+      const src = getLiquidText("lCurr != rCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical phone number", function () {
+      const src = getLiquidText("lPhone != lPhone");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical phone number", function () {
+      const src = getLiquidText("lPhone != rPhone");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+  });
+
+  describe("custom operators/>", () => {
+    it("should eval identical strings", function () {
+      const src = getLiquidText("lStr > lStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical strings - 1", function () {
+      const src = getLiquidText("lStr > rStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical strings - 2", function () {
+      const src = getLiquidText("rStr > lStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical numbers", function () {
+      const src = getLiquidText("lNum > lNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical numbers - 1", function () {
+      const src = getLiquidText("lNum > rNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical numbers - 2", function () {
+      const src = getLiquidText("rNum > lNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical booleans", function () {
+      const src = getLiquidText("lBool > lBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical booleans - 1", function () {
+      const src = getLiquidText("lBool > rBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical booleans - 2", function () {
+      const src = getLiquidText("rBool > lBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical dates", function () {
+      const src = getLiquidText("lDate > lDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical dates - 1", function () {
+      const src = getLiquidText("lDate > rDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical dates - 2", function () {
+      const src = getLiquidText("rDate > lDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical duration", function () {
+      const src = getLiquidText("lDur > lDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical duration - 1", function () {
+      const src = getLiquidText("lDur > rDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical duration - 2", function () {
+      const src = getLiquidText("rDur > lDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical currency", function () {
+      const src = getLiquidText("lCurr > lCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical currency - 1", function () {
+      const src = getLiquidText("lCurr > rCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical currency - 2", function () {
+      const src = getLiquidText("rCurr > lCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+  });
+
+  describe("custom operators/>=", () => {
+    it("should eval identical strings", function () {
+      const src = getLiquidText("lStr >= lStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical strings - 1", function () {
+      const src = getLiquidText("lStr >= rStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical strings - 2", function () {
+      const src = getLiquidText("rStr >= lStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical numbers", function () {
+      const src = getLiquidText("lNum >= lNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical numbers - 1", function () {
+      const src = getLiquidText("lNum >= rNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical numbers - 2", function () {
+      const src = getLiquidText("rNum >= lNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical booleans", function () {
+      const src = getLiquidText("lBool >= lBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical booleans - 1", function () {
+      const src = getLiquidText("lBool >= rBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical booleans - 2", function () {
+      const src = getLiquidText("rBool >= lBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical dates", function () {
+      const src = getLiquidText("lDate >= lDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical dates - 1", function () {
+      const src = getLiquidText("lDate >= rDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical dates - 2", function () {
+      const src = getLiquidText("rDate >= lDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical duration", function () {
+      const src = getLiquidText("lDur >= lDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical duration - 1", function () {
+      const src = getLiquidText("lDur >= rDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical duration - 2", function () {
+      const src = getLiquidText("rDur >= lDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval identical currency", function () {
+      const src = getLiquidText("lCurr >= lCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical currency - 1", function () {
+      const src = getLiquidText("lCurr >= rCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical currency - 2", function () {
+      const src = getLiquidText("rCurr >= lCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+  });
+
+  describe("custom operators/<", () => {
+    it("should eval identical strings", function () {
+      const src = getLiquidText("lStr < lStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical strings - 1", function () {
+      const src = getLiquidText("lStr < rStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical strings - 2", function () {
+      const src = getLiquidText("rStr < lStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical numbers", function () {
+      const src = getLiquidText("lNum < lNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical numbers - 1", function () {
+      const src = getLiquidText("lNum < rNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical numbers - 2", function () {
+      const src = getLiquidText("rNum < lNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical booleans", function () {
+      const src = getLiquidText("lBool < lBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical booleans - 1", function () {
+      const src = getLiquidText("lBool < rBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical booleans - 2", function () {
+      const src = getLiquidText("rBool < lBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical dates", function () {
+      const src = getLiquidText("lDate < lDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical dates - 1", function () {
+      const src = getLiquidText("lDate < rDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical dates - 2", function () {
+      const src = getLiquidText("rDate < lDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical duration", function () {
+      const src = getLiquidText("lDur < lDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical duration - 1", function () {
+      const src = getLiquidText("lDur < rDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical duration - 2", function () {
+      const src = getLiquidText("rDur < lDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical currency", function () {
+      const src = getLiquidText("lCurr < lCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval non identical currency - 1", function () {
+      const src = getLiquidText("lCurr < rCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical currency - 2", function () {
+      const src = getLiquidText("rCurr < lCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+  });
+
+  describe("custom operators/<=", () => {
+    it("should eval identical strings", function () {
+      const src = getLiquidText("lStr <= lStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical strings - 1", function () {
+      const src = getLiquidText("lStr <= rStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical strings - 2", function () {
+      const src = getLiquidText("rStr <= lStr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical numbers", function () {
+      const src = getLiquidText("lNum <= lNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical numbers - 1", function () {
+      const src = getLiquidText("lNum <= rNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical numbers - 2", function () {
+      const src = getLiquidText("rNum <= lNum");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical booleans", function () {
+      const src = getLiquidText("lBool <= lBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical booleans - 1", function () {
+      const src = getLiquidText("lBool <= rBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical booleans - 2", function () {
+      const src = getLiquidText("rBool <= lBool");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical dates", function () {
+      const src = getLiquidText("lDate <= lDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical dates - 1", function () {
+      const src = getLiquidText("lDate <= rDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical dates - 2", function () {
+      const src = getLiquidText("rDate <= lDate");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical duration", function () {
+      const src = getLiquidText("lDur <= lDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical duration - 1", function () {
+      const src = getLiquidText("lDur <= rDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical duration - 2", function () {
+      const src = getLiquidText("rDur <= lDur");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+
+    it("should eval identical currency", function () {
+      const src = getLiquidText("lCurr <= lCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical currency - 1", function () {
+      const src = getLiquidText("lCurr <= rCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(TRUE);
+    });
+
+    it("should eval non identical currency - 2", function () {
+      const src = getLiquidText("rCurr <= lCurr");
+      return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(FALSE);
+    });
+  });
+});

--- a/test/sd-custom/custom-operator/equals.js
+++ b/test/sd-custom/custom-operator/equals.js
@@ -1,0 +1,153 @@
+const chai = require("chai");
+const expect = chai.expect;
+
+const equals = require("../../../sd-custom/custom-operator/equals.js");
+
+describe("Custom equals operator", () => {
+  it("should eval numbers correctly", () => {
+    expect(equals(0, 0)).to.equal(true);
+    expect(equals(-10, -10)).to.equal(true);
+    expect(equals(10, 10)).to.equal(true);
+    expect(equals(1, 2)).to.equal(false);
+  });
+
+  it("should eval string correctly", () => {
+    expect(equals("", "")).to.equal(true);
+    expect(equals("abc", "abc")).to.equal(true);
+    expect(equals("123", "123")).to.equal(true);
+    expect(equals("abc", "abd")).to.equal(false);
+  });
+
+  it("should eval boolean correctly", () => {
+    expect(equals(true, true)).to.equal(true);
+    expect(equals(false, false)).to.equal(true);
+    expect(equals(true, false)).to.equal(false);
+  });
+
+  describe("should eval array correctly", () => {
+    it("should return true for empty array", () => {
+      expect(equals([], [])).to.equal(true);
+    });
+    it("should return true for identical arrays", () => {
+      expect(equals([1, 2, 3], [1, 2, 3])).to.equal(true);
+    });
+    it("should return true for identical unsorted arrays", () => {
+      expect(equals([1, 2, 3], [3, 2, 1])).to.equal(true);
+    });
+    it("should return true for identical unsorted string arrays", () => {
+      expect(equals(["a", "b"], ["b", "a"])).to.equal(true);
+    });
+    it("should return false for non identical arrays", () => {
+      expect(equals([1, 2, 3], [1, 2])).to.equal(false);
+    });
+    it("should return false for identical object arrays", () => {
+      expect(equals([{ x: 1 }, { x: 2 }], [{ x: 1 }, { x: 2 }])).to.equal(
+        false
+      );
+    });
+  });
+
+  describe("should eval duration correctly", () => {
+    const dur1 = {
+      value: 1,
+      type: "YEARS",
+      days: 365,
+    };
+
+    const dur2 = {
+      value: 1,
+      type: "YEARS",
+      days: 365,
+    };
+
+    const dur3 = {
+      value: 2,
+      type: "MONTHS",
+      days: 60,
+    };
+
+    it("should return true for identical duration", () => {
+      expect(equals(dur1, dur2)).to.equal(true);
+    });
+    it("should return false for non identical duration", () => {
+      expect(equals(dur1, dur3)).to.equal(false);
+    });
+  });
+
+  describe("should eval date correctly", () => {
+    const date1 = new Date(Date.UTC(2000, 0, 1)).toISOString();
+    const date2 = "2000-01-01";
+    const date3 = "2001-01-01";
+    const date4 = "01-01-2001";
+
+    it("should return true for identical dates", () => {
+      expect(equals(date1, date1)).to.equal(true);
+    });
+    it("should return true for identical dates of different formats", () => {
+      expect(equals(date1, date2)).to.equal(true);
+    });
+    it("should return false for non identical dates", () => {
+      expect(equals(date2, date3)).to.equal(false);
+    });
+    it("should return false for unsupported date format", () => {
+      expect(equals(date3, date4)).to.equal(false);
+    });
+  });
+
+  describe("should eval currency correctly", () => {
+    const curr1 = {
+      value: 100,
+      type: "USD",
+    };
+
+    const curr2 = {
+      value: 200,
+      type: "USD",
+    };
+
+    const curr3 = {
+      value: 100,
+      type: "INR",
+    };
+
+    it("should return true for identical currency", () => {
+      expect(equals(curr1, { ...curr1 })).to.equal(true);
+    });
+    it("should return false for non identical currency values", () => {
+      expect(equals(curr1, curr2)).to.equal(false);
+    });
+    it("should return false for non identical currency type", () => {
+      expect(equals(curr1, curr3)).to.equal(false);
+    });
+  });
+
+  describe("should eval phone number correctly", () => {
+    const ph1 = {
+      number: "9876543210",
+      code: "+1",
+      country_code: "+1",
+    };
+
+    const ph2 = {
+      number: "1111111",
+      code: "+1",
+      country_code: "+1",
+    };
+
+    const ph3 = {
+      number: "9876543210",
+      code: "+91",
+      country_code: "+91",
+    };
+
+    it("should return true for identical phone number", () => {
+      expect(equals(ph1, { ...ph1 })).to.equal(true);
+    });
+    it("should return false for non identical phone number values", () => {
+      expect(equals(ph1, ph2)).to.equal(false);
+    });
+    it("should return false for non identical phone number code", () => {
+      expect(equals(ph1, ph3)).to.equal(false);
+    });
+  });
+});

--- a/test/sd-custom/custom-operator/greater-or-equal.js
+++ b/test/sd-custom/custom-operator/greater-or-equal.js
@@ -1,0 +1,105 @@
+const chai = require("chai");
+const expect = chai.expect;
+
+const greaterThanOrEqual = require("../../../sd-custom/custom-operator/greater-or-equal.js");
+
+describe("Custom greater or equals operator", () => {
+  it("should eval numbers correctly", () => {
+    expect(greaterThanOrEqual(0, 0)).to.equal(true);
+    expect(greaterThanOrEqual(-1, -2)).to.equal(true);
+    expect(greaterThanOrEqual(100, 10)).to.equal(true);
+    expect(greaterThanOrEqual(1, 2)).to.equal(false);
+  });
+
+  it("should eval string correctly", () => {
+    expect(greaterThanOrEqual("", "")).to.equal(true);
+    expect(greaterThanOrEqual("abc", "abc")).to.equal(true);
+    expect(greaterThanOrEqual("abd", "abc")).to.equal(true);
+    expect(greaterThanOrEqual("abc", "abd")).to.equal(false);
+    expect(greaterThanOrEqual("abc", "ab")).to.equal(true);
+    expect(greaterThanOrEqual("abc", "")).to.equal(true);
+  });
+
+  it("should eval boolean correctly", () => {
+    expect(greaterThanOrEqual(true, true)).to.equal(true);
+    expect(greaterThanOrEqual(false, false)).to.equal(true);
+    expect(greaterThanOrEqual(true, false)).to.equal(true);
+  });
+
+  it("should eval duration correctly", () => {
+    const dur1 = {
+      value: 1,
+      type: "YEARS",
+      days: 365,
+    };
+
+    const dur2 = {
+      value: 2,
+      type: "YEARS",
+      days: 2 * 365,
+    };
+
+    const dur3 = {
+      value: 2,
+      type: "MONTHS",
+      days: 2 * 30,
+    };
+
+    expect(greaterThanOrEqual(dur1, { ...dur1 })).to.equal(true);
+    expect(greaterThanOrEqual(dur1, dur2)).to.equal(false);
+    expect(greaterThanOrEqual(dur1, dur3)).to.equal(true);
+    expect(greaterThanOrEqual(dur2, dur3)).to.equal(true);
+  });
+
+  describe("should eval date correctly", () => {
+    const date1 = new Date(Date.UTC(2000, 0, 1)).toISOString();
+    const date2 = "2000-01-01";
+    const date3 = "2001-01-01";
+    const date4 = "01-01-2001";
+
+    it("should return true for identical dates", () => {
+      expect(greaterThanOrEqual(date1, date1)).to.equal(true);
+    });
+    it("should eval dates", () => {
+      expect(greaterThanOrEqual(date3, date2)).to.equal(true);
+      expect(greaterThanOrEqual(date2, date3)).to.equal(false);
+    });
+    it("should eval dates of different formats", () => {
+      expect(greaterThanOrEqual(date1, date2)).to.equal(true);
+      expect(greaterThanOrEqual(date3, date1)).to.equal(true);
+      expect(greaterThanOrEqual(date1, date3)).to.equal(false);
+    });
+
+    it("should return false for unsupported date format", () => {
+      expect(greaterThanOrEqual(date3, date4)).to.equal(false);
+    });
+  });
+
+  describe("should eval currency correctly", () => {
+    const curr1 = {
+      value: 100,
+      type: "USD",
+    };
+
+    const curr2 = {
+      value: 200,
+      type: "USD",
+    };
+
+    const curr3 = {
+      value: 100,
+      type: "INR",
+    };
+
+    it("should return true for identical currency", () => {
+      expect(greaterThanOrEqual(curr1, { ...curr1 })).to.equal(true);
+    });
+    it("should eval currency values", () => {
+      expect(greaterThanOrEqual(curr1, curr2)).to.equal(false);
+      expect(greaterThanOrEqual(curr2, curr1)).to.equal(true);
+    });
+    it("should return false for non identical currency type", () => {
+      expect(greaterThanOrEqual(curr2, curr3)).to.equal(false);
+    });
+  });
+});

--- a/test/sd-custom/custom-operator/greater.js
+++ b/test/sd-custom/custom-operator/greater.js
@@ -1,0 +1,104 @@
+const chai = require("chai");
+const expect = chai.expect;
+
+const greater = require("../../../sd-custom/custom-operator/greater.js");
+
+describe("Custom greater than operator", () => {
+  it("should eval numbers correctly", () => {
+    expect(greater(0, 0)).to.equal(false);
+    expect(greater(-1, -2)).to.equal(true);
+    expect(greater(100, 10)).to.equal(true);
+    expect(greater(1, 2)).to.equal(false);
+  });
+
+  it("should eval string correctly", () => {
+    expect(greater("", "")).to.equal(false);
+    expect(greater("abc", "abc")).to.equal(false);
+    expect(greater("abd", "abc")).to.equal(true);
+    expect(greater("abc", "abd")).to.equal(false);
+    expect(greater("abc", "ab")).to.equal(true);
+    expect(greater("abc", "")).to.equal(true);
+  });
+
+  it("should eval boolean correctly", () => {
+    expect(greater(true, true)).to.equal(false);
+    expect(greater(false, false)).to.equal(false);
+    expect(greater(true, false)).to.equal(true);
+  });
+
+  it("should eval duration correctly", () => {
+    const dur1 = {
+      value: 1,
+      type: "YEARS",
+      days: 365,
+    };
+
+    const dur2 = {
+      value: 2,
+      type: "YEARS",
+      days: 2 * 365,
+    };
+
+    const dur3 = {
+      value: 2,
+      type: "MONTHS",
+      days: 2 * 30,
+    };
+
+    expect(greater(dur1, { ...dur1 })).to.equal(false);
+    expect(greater(dur1, dur2)).to.equal(false);
+    expect(greater(dur1, dur3)).to.equal(true);
+    expect(greater(dur2, dur3)).to.equal(true);
+  });
+
+  describe("should eval date correctly", () => {
+    const date1 = new Date(Date.UTC(2000, 0, 1)).toISOString();
+    const date2 = "2000-01-01";
+    const date3 = "2001-01-01";
+    const date4 = "01-01-2001";
+
+    it("should return false for identical dates", () => {
+      expect(greater(date1, date1)).to.equal(false);
+    });
+    it("should eval dates", () => {
+      expect(greater(date3, date2)).to.equal(true);
+      expect(greater(date2, date3)).to.equal(false);
+    });
+    it("should eval dates of different formats", () => {
+      expect(greater(date1, date2)).to.equal(false);
+      expect(greater(date3, date1)).to.equal(true);
+    });
+
+    it("should return false for unsupported date format", () => {
+      expect(greater(date3, date4)).to.equal(false);
+    });
+  });
+
+  describe("should eval currency correctly", () => {
+    const curr1 = {
+      value: 100,
+      type: "USD",
+    };
+
+    const curr2 = {
+      value: 200,
+      type: "USD",
+    };
+
+    const curr3 = {
+      value: 100,
+      type: "INR",
+    };
+
+    it("should return false for identical currency", () => {
+      expect(greater(curr1, { ...curr1 })).to.equal(false);
+    });
+    it("should eval currency values", () => {
+      expect(greater(curr1, curr2)).to.equal(false);
+      expect(greater(curr2, curr1)).to.equal(true);
+    });
+    it("should return false for non identical currency type", () => {
+      expect(greater(curr2, curr3)).to.equal(false);
+    });
+  });
+});

--- a/test/sd-custom/custom-operator/smaller-or-equal.js
+++ b/test/sd-custom/custom-operator/smaller-or-equal.js
@@ -1,0 +1,106 @@
+const chai = require("chai");
+const expect = chai.expect;
+
+const smallerThanOrEqual = require("../../../sd-custom/custom-operator/smaller-or-equal.js");
+
+describe("Custom smaller or equals operator", () => {
+  it("should eval numbers correctly", () => {
+    expect(smallerThanOrEqual(0, 0)).to.equal(true);
+    expect(smallerThanOrEqual(-1, -2)).to.equal(false);
+    expect(smallerThanOrEqual(100, 10)).to.equal(false);
+    expect(smallerThanOrEqual(1, 2)).to.equal(true);
+  });
+
+  it("should eval string correctly", () => {
+    expect(smallerThanOrEqual("", "")).to.equal(true);
+    expect(smallerThanOrEqual("abc", "abc")).to.equal(true);
+    expect(smallerThanOrEqual("abd", "abc")).to.equal(false);
+    expect(smallerThanOrEqual("abc", "abd")).to.equal(true);
+    expect(smallerThanOrEqual("ab", "abc")).to.equal(true);
+    expect(smallerThanOrEqual("abc", "")).to.equal(false);
+  });
+
+  it("should eval boolean correctly", () => {
+    expect(smallerThanOrEqual(true, true)).to.equal(true);
+    expect(smallerThanOrEqual(false, false)).to.equal(true);
+    expect(smallerThanOrEqual(true, false)).to.equal(false);
+  });
+
+  it("should eval duration correctly", () => {
+    const dur1 = {
+      value: 1,
+      type: "YEARS",
+      days: 365,
+    };
+
+    const dur2 = {
+      value: 2,
+      type: "YEARS",
+      days: 2 * 365,
+    };
+
+    const dur3 = {
+      value: 2,
+      type: "MONTHS",
+      days: 2 * 30,
+    };
+
+    expect(smallerThanOrEqual(dur1, { ...dur1 })).to.equal(true);
+    expect(smallerThanOrEqual(dur1, dur2)).to.equal(true);
+    expect(smallerThanOrEqual(dur1, dur3)).to.equal(false);
+    expect(smallerThanOrEqual(dur2, dur3)).to.equal(false);
+    expect(smallerThanOrEqual(dur3, dur1)).to.equal(true);
+  });
+
+  describe("should eval date correctly", () => {
+    const date1 = new Date(Date.UTC(2000, 0, 1)).toISOString();
+    const date2 = "2000-01-01";
+    const date3 = "2001-01-01";
+    const date4 = "01-01-2001";
+
+    it("should return true for identical dates", () => {
+      expect(smallerThanOrEqual(date1, date1)).to.equal(true);
+    });
+    it("should eval dates", () => {
+      expect(smallerThanOrEqual(date3, date2)).to.equal(false);
+      expect(smallerThanOrEqual(date2, date3)).to.equal(true);
+    });
+    it("should eval dates of different formats", () => {
+      expect(smallerThanOrEqual(date1, date2)).to.equal(true);
+      expect(smallerThanOrEqual(date3, date1)).to.equal(false);
+      expect(smallerThanOrEqual(date1, date3)).to.equal(true);
+    });
+
+    it("should return false for unsupported date format", () => {
+      expect(smallerThanOrEqual(date3, date4)).to.equal(false);
+    });
+  });
+
+  describe("should eval currency correctly", () => {
+    const curr1 = {
+      value: 100,
+      type: "USD",
+    };
+
+    const curr2 = {
+      value: 200,
+      type: "USD",
+    };
+
+    const curr3 = {
+      value: 100,
+      type: "INR",
+    };
+
+    it("should return true for identical currency", () => {
+      expect(smallerThanOrEqual(curr1, { ...curr1 })).to.equal(true);
+    });
+    it("should eval currency values", () => {
+      expect(smallerThanOrEqual(curr1, curr2)).to.equal(true);
+      expect(smallerThanOrEqual(curr2, curr1)).to.equal(false);
+    });
+    it("should return false for non identical currency type", () => {
+      expect(smallerThanOrEqual(curr2, curr3)).to.equal(false);
+    });
+  });
+});

--- a/test/sd-custom/custom-operator/smaller.js
+++ b/test/sd-custom/custom-operator/smaller.js
@@ -1,0 +1,106 @@
+const chai = require("chai");
+const expect = chai.expect;
+
+const smaller = require("../../../sd-custom/custom-operator/smaller.js");
+
+describe("Custom smaller than operator", () => {
+  it("should eval numbers correctly", () => {
+    expect(smaller(0, 0)).to.equal(false);
+    expect(smaller(-1, -2)).to.equal(false);
+    expect(smaller(100, 10)).to.equal(false);
+    expect(smaller(1, 2)).to.equal(true);
+  });
+
+  it("should eval string correctly", () => {
+    expect(smaller("", "")).to.equal(false);
+    expect(smaller("abc", "abc")).to.equal(false);
+    expect(smaller("abd", "abc")).to.equal(false);
+    expect(smaller("abc", "abd")).to.equal(true);
+    expect(smaller("ab", "abc")).to.equal(true);
+    expect(smaller("abc", "")).to.equal(false);
+  });
+
+  it("should eval boolean correctly", () => {
+    expect(smaller(true, true)).to.equal(false);
+    expect(smaller(false, false)).to.equal(false);
+    expect(smaller(true, false)).to.equal(false);
+  });
+
+  it("should eval duration correctly", () => {
+    const dur1 = {
+      value: 1,
+      type: "YEARS",
+      days: 365,
+    };
+
+    const dur2 = {
+      value: 2,
+      type: "YEARS",
+      days: 2 * 365,
+    };
+
+    const dur3 = {
+      value: 2,
+      type: "MONTHS",
+      days: 2 * 30,
+    };
+
+    expect(smaller(dur1, { ...dur1 })).to.equal(false);
+    expect(smaller(dur1, dur2)).to.equal(true);
+    expect(smaller(dur1, dur3)).to.equal(false);
+    expect(smaller(dur2, dur3)).to.equal(false);
+    expect(smaller(dur3, dur1)).to.equal(true);
+  });
+
+  describe("should eval date correctly", () => {
+    const date1 = new Date(Date.UTC(2000, 0, 1)).toISOString();
+    const date2 = "2000-01-01";
+    const date3 = "2001-01-01";
+    const date4 = "01-01-2001";
+
+    it("should return false for identical dates", () => {
+      expect(smaller(date1, date1)).to.equal(false);
+    });
+    it("should eval dates", () => {
+      expect(smaller(date3, date2)).to.equal(false);
+      expect(smaller(date2, date3)).to.equal(true);
+    });
+    it("should eval dates of different formats", () => {
+      expect(smaller(date1, date2)).to.equal(false);
+      expect(smaller(date3, date1)).to.equal(false);
+      expect(smaller(date1, date3)).to.equal(true);
+    });
+
+    it("should return false for unsupported date format", () => {
+      expect(smaller(date3, date4)).to.equal(false);
+    });
+  });
+
+  describe("should eval currency correctly", () => {
+    const curr1 = {
+      value: 100,
+      type: "USD",
+    };
+
+    const curr2 = {
+      value: 200,
+      type: "USD",
+    };
+
+    const curr3 = {
+      value: 100,
+      type: "INR",
+    };
+
+    it("should return false for identical currency", () => {
+      expect(smaller(curr1, { ...curr1 })).to.equal(false);
+    });
+    it("should eval currency values", () => {
+      expect(smaller(curr1, curr2)).to.equal(true);
+      expect(smaller(curr2, curr1)).to.equal(false);
+    });
+    it("should return false for non identical currency type", () => {
+      expect(smaller(curr2, curr3)).to.equal(false);
+    });
+  });
+});

--- a/test/sd-custom/type-assert.js
+++ b/test/sd-custom/type-assert.js
@@ -80,18 +80,18 @@ describe("sd-custom type assertions", () => {
       country_code: "+1",
     };
 
-    const invalidPhoneNumber1 = {
+    const invalidPhoneNumber = {
       number: "1111111",
       country_code: "+1",
     };
 
-    const invalidPhoneNumber2 = {
+    const validPhoneNumber2 = {
       number: "9876543210",
       code: "+91",
     };
 
     expect(getType(validPhoneNumber)).to.equal(SD_CUSTOM_TYPES.phoneNumber);
-    expect(getType(invalidPhoneNumber1)).to.be.undefined;
-    expect(getType(invalidPhoneNumber2)).to.be.undefined;
+    expect(getType(invalidPhoneNumber)).to.be.undefined;
+    expect(getType(validPhoneNumber2)).to.equal(SD_CUSTOM_TYPES.phoneNumber);
   });
 });

--- a/test/sd-custom/type-assert.js
+++ b/test/sd-custom/type-assert.js
@@ -1,0 +1,97 @@
+const chai = require("chai");
+const expect = chai.expect;
+
+const { getType, SD_CUSTOM_TYPES } = require("../../sd-custom/type-assert.js");
+
+describe("sd-custom type assertions", () => {
+  it("should return undefined for undefined, null, NaN", () => {
+    expect(getType(undefined)).to.be.undefined;
+    expect(getType(null)).to.be.undefined;
+    expect(getType(+"a")).to.be.undefined;
+  });
+
+  it("should handle string values", () => {
+    expect(getType("hello")).to.equal(SD_CUSTOM_TYPES.string);
+    expect(getType("")).to.equal(SD_CUSTOM_TYPES.string);
+  });
+
+  it("should handle number values", () => {
+    expect(getType(100)).to.equal(SD_CUSTOM_TYPES.number);
+    expect(getType(-100)).to.equal(SD_CUSTOM_TYPES.number);
+  });
+
+  it("should handle boolean values", () => {
+    expect(getType(true)).to.equal(SD_CUSTOM_TYPES.boolean);
+    expect(getType(false)).to.equal(SD_CUSTOM_TYPES.boolean);
+  });
+
+  it("should handle date string values", () => {
+    expect(getType(new Date(2000, 0, 1).toISOString())).to.equal(
+      SD_CUSTOM_TYPES.date
+    );
+    expect(getType("2020-01-01")).to.equal(SD_CUSTOM_TYPES.date);
+    expect(getType("01-01-2020")).to.equal(SD_CUSTOM_TYPES.string);
+  });
+
+  it("should handle array values", () => {
+    expect(getType([])).to.equal(SD_CUSTOM_TYPES.array);
+    expect(getType([1, 2, 3])).to.equal(SD_CUSTOM_TYPES.array);
+    expect(getType(["A", "b"])).to.equal(SD_CUSTOM_TYPES.array);
+    expect(getType([{ x: 1 }, { x: 2 }])).to.equal(SD_CUSTOM_TYPES.array);
+  });
+
+  it("should handle duration values", () => {
+    const validDuration = {
+      value: 1,
+      type: "YEARS",
+      days: 365,
+    };
+    const invalidDuration1 = {
+      value: 1,
+      days: 365,
+    };
+    const invalidDuration2 = {
+      value: 1,
+      type: "CENTURY",
+      days: 365,
+    };
+    expect(getType(validDuration)).to.equal(SD_CUSTOM_TYPES.duration);
+    expect(getType(invalidDuration1)).to.be.undefined;
+    // invalidDuration2 won't pass duration check but will pass currency check
+    expect(getType(invalidDuration2)).to.equal(SD_CUSTOM_TYPES.currency);
+  });
+
+  it("should handle currency values", () => {
+    const validCurrency = {
+      value: 1,
+      type: "YEARS",
+    };
+    const invalidCurrency = {
+      value: 1,
+    };
+    expect(getType(validCurrency)).to.equal(SD_CUSTOM_TYPES.currency);
+    expect(getType(invalidCurrency)).to.be.undefined;
+  });
+
+  it("should handle phone number values", () => {
+    const validPhoneNumber = {
+      number: "9876543210",
+      code: "+1",
+      country_code: "+1",
+    };
+
+    const invalidPhoneNumber1 = {
+      number: "1111111",
+      country_code: "+1",
+    };
+
+    const invalidPhoneNumber2 = {
+      number: "9876543210",
+      code: "+91",
+    };
+
+    expect(getType(validPhoneNumber)).to.equal(SD_CUSTOM_TYPES.phoneNumber);
+    expect(getType(invalidPhoneNumber1)).to.be.undefined;
+    expect(getType(invalidPhoneNumber2)).to.be.undefined;
+  });
+});


### PR DESCRIPTION
- override existing operators to use custom operators
- add support to directly compare currency, duration, date, phone-number, array using relational operators
- added a lot of test cases around it and verified that all of them are passing