### PR TITLE
use default liquidjs handling for operands of unequal types

### DIFF
--- a/sd-custom/custom-operator/equals.js
+++ b/sd-custom/custom-operator/equals.js
@@ -95,12 +95,16 @@ function arrayEquals(l, r) {
   });
 }
 
+function defaultHandler(l, r) {
+  return l === r;
+}
+
 function equals(l, r) {
   const lType = getType(l);
   const rType = getType(r);
 
   if (lType !== rType) {
-    return false;
+    return defaultHandler(l, r);
   }
 
   switch (lType) {
@@ -115,7 +119,7 @@ function equals(l, r) {
     case SD_CUSTOM_TYPES.phoneNumber:
       return phoneNumberEquals(l, r);
     default:
-      return l === r;
+      return defaultHandler(l, r);
   }
 }
 

--- a/sd-custom/custom-operator/greater-or-equal.js
+++ b/sd-custom/custom-operator/greater-or-equal.js
@@ -45,12 +45,16 @@ function currencyGreaterThanOrEqual(l, r) {
   return l.value >= r.value && l.type === r.type;
 }
 
+function defaultHandler(l, r) {
+  return l >= r;
+}
+
 function greaterThanOrEqual(l, r) {
   const lType = getType(l);
   const rType = getType(r);
 
   if (lType !== rType) {
-    return false;
+    return defaultHandler(l, r);
   }
 
   switch (lType) {
@@ -61,7 +65,7 @@ function greaterThanOrEqual(l, r) {
     case SD_CUSTOM_TYPES.date:
       return dateGreaterThanOrEqual(l, r);
     default:
-      return l >= r;
+      return defaultHandler(l, r);
   }
 }
 

--- a/sd-custom/custom-operator/greater.js
+++ b/sd-custom/custom-operator/greater.js
@@ -45,12 +45,16 @@ function currencyGreaterThan(l, r) {
   return l.value > r.value && l.type === r.type;
 }
 
+function defaultHandler(l, r) {
+  return l > r;
+}
+
 function greaterThan(l, r) {
   const lType = getType(l);
   const rType = getType(r);
 
   if (lType !== rType) {
-    return false;
+    return defaultHandler(l, r);
   }
 
   switch (lType) {
@@ -61,7 +65,7 @@ function greaterThan(l, r) {
     case SD_CUSTOM_TYPES.date:
       return dateGreaterThan(l, r);
     default:
-      return l > r;
+      return defaultHandler(l, r);
   }
 }
 

--- a/sd-custom/custom-operator/smaller-or-equal.js
+++ b/sd-custom/custom-operator/smaller-or-equal.js
@@ -45,12 +45,16 @@ function currencySmallerThanOrEqual(l, r) {
   return l.value <= r.value && l.type === r.type;
 }
 
+function defaultHandler(l, r) {
+  return l <= r;
+}
+
 function smallerThanOrEqual(l, r) {
   const lType = getType(l);
   const rType = getType(r);
 
   if (lType !== rType) {
-    return false;
+    return defaultHandler(l, r);
   }
 
   switch (lType) {
@@ -61,7 +65,7 @@ function smallerThanOrEqual(l, r) {
     case SD_CUSTOM_TYPES.date:
       return dateSmallerThanOrEqual(l, r);
     default:
-      return l <= r;
+      return defaultHandler(l, r);
   }
 }
 

--- a/sd-custom/custom-operator/smaller.js
+++ b/sd-custom/custom-operator/smaller.js
@@ -45,12 +45,16 @@ function currencySmaller(l, r) {
   return l.value < r.value && l.type === r.type;
 }
 
+function defaultHandler(l, r) {
+  return l < r;
+}
+
 function smaller(l, r) {
   const lType = getType(l);
   const rType = getType(r);
 
   if (lType !== rType) {
-    return false;
+    return defaultHandler(l, r);
   }
 
   switch (lType) {
@@ -61,7 +65,7 @@ function smaller(l, r) {
     case SD_CUSTOM_TYPES.date:
       return dateSmaller(l, r);
     default:
-      return l < r;
+      return defaultHandler(l, r);
   }
 }
 

--- a/test/sd-custom/custom-operator/equals.js
+++ b/test/sd-custom/custom-operator/equals.js
@@ -4,6 +4,14 @@ const expect = chai.expect;
 const equals = require("../../../sd-custom/custom-operator/equals.js");
 
 describe("Custom equals operator", () => {
+  it("should use default evaluation for operands of different types", () => {
+    expect(equals(1, "1")).to.equal(1 === "1");
+    expect(equals(5, "1")).to.equal(5 === "1");
+    expect(equals("1", 5)).to.equal("1" === 5);
+    expect(equals("5", true)).to.equal("5" === true);
+    expect(equals(5, {})).to.equal(5 === {});
+  });
+
   it("should eval numbers correctly", () => {
     expect(equals(0, 0)).to.equal(true);
     expect(equals(-10, -10)).to.equal(true);
@@ -90,7 +98,7 @@ describe("Custom equals operator", () => {
       expect(equals(date2, date3)).to.equal(false);
     });
     it("should return false for unsupported date format", () => {
-      expect(equals(date3, date4)).to.equal(false);
+      expect(equals(date3, date4)).to.equal(date3 === date4);
     });
   });
 

--- a/test/sd-custom/custom-operator/greater-or-equal.js
+++ b/test/sd-custom/custom-operator/greater-or-equal.js
@@ -4,6 +4,14 @@ const expect = chai.expect;
 const greaterThanOrEqual = require("../../../sd-custom/custom-operator/greater-or-equal.js");
 
 describe("Custom greater or equals operator", () => {
+  it("should use default evaluation for operands of different types", () => {
+    expect(greaterThanOrEqual(1, "1")).to.equal(1 >= "1");
+    expect(greaterThanOrEqual(5, "1")).to.equal(5 >= "1");
+    expect(greaterThanOrEqual("1", 5)).to.equal("1" >= 5);
+    expect(greaterThanOrEqual("5", true)).to.equal("5" >= true);
+    expect(greaterThanOrEqual(5, {})).to.equal(5 >= {});
+  });
+
   it("should eval numbers correctly", () => {
     expect(greaterThanOrEqual(0, 0)).to.equal(true);
     expect(greaterThanOrEqual(-1, -2)).to.equal(true);
@@ -71,7 +79,7 @@ describe("Custom greater or equals operator", () => {
     });
 
     it("should return false for unsupported date format", () => {
-      expect(greaterThanOrEqual(date3, date4)).to.equal(false);
+      expect(greaterThanOrEqual(date3, date4)).to.equal(date3 >= date4);
     });
   });
 

--- a/test/sd-custom/custom-operator/greater.js
+++ b/test/sd-custom/custom-operator/greater.js
@@ -4,6 +4,14 @@ const expect = chai.expect;
 const greater = require("../../../sd-custom/custom-operator/greater.js");
 
 describe("Custom greater than operator", () => {
+  it("should use default evaluation for operands of different types", () => {
+    expect(greater(1, "1")).to.equal(1 > "1");
+    expect(greater(5, "1")).to.equal(5 > "1");
+    expect(greater("1", 5)).to.equal("1" > 5);
+    expect(greater("5", true)).to.equal("5" > true);
+    expect(greater(5, {})).to.equal(5 > {});
+  });
+
   it("should eval numbers correctly", () => {
     expect(greater(0, 0)).to.equal(false);
     expect(greater(-1, -2)).to.equal(true);
@@ -70,7 +78,7 @@ describe("Custom greater than operator", () => {
     });
 
     it("should return false for unsupported date format", () => {
-      expect(greater(date3, date4)).to.equal(false);
+      expect(greater(date3, date4)).to.equal(date3 > date4);
     });
   });
 

--- a/test/sd-custom/custom-operator/smaller-or-equal.js
+++ b/test/sd-custom/custom-operator/smaller-or-equal.js
@@ -4,6 +4,14 @@ const expect = chai.expect;
 const smallerThanOrEqual = require("../../../sd-custom/custom-operator/smaller-or-equal.js");
 
 describe("Custom smaller or equals operator", () => {
+  it("should use default evaluation for operands of different types", () => {
+    expect(smallerThanOrEqual(1, "1")).to.equal(1 <= "1");
+    expect(smallerThanOrEqual(5, "1")).to.equal(5 <= "1");
+    expect(smallerThanOrEqual("1", 5)).to.equal("1" <= 5);
+    expect(smallerThanOrEqual("5", true)).to.equal("5" <= true);
+    expect(smallerThanOrEqual(5, {})).to.equal(5 <= {});
+  });
+
   it("should eval numbers correctly", () => {
     expect(smallerThanOrEqual(0, 0)).to.equal(true);
     expect(smallerThanOrEqual(-1, -2)).to.equal(false);
@@ -72,7 +80,7 @@ describe("Custom smaller or equals operator", () => {
     });
 
     it("should return false for unsupported date format", () => {
-      expect(smallerThanOrEqual(date3, date4)).to.equal(false);
+      expect(smallerThanOrEqual(date3, date4)).to.equal(date3 <= date4);
     });
   });
 

--- a/test/sd-custom/custom-operator/smaller.js
+++ b/test/sd-custom/custom-operator/smaller.js
@@ -4,6 +4,14 @@ const expect = chai.expect;
 const smaller = require("../../../sd-custom/custom-operator/smaller.js");
 
 describe("Custom smaller than operator", () => {
+  it("should use default evaluation for operands of different types", () => {
+    expect(smaller(1, "1")).to.equal(1 < "1");
+    expect(smaller(5, "1")).to.equal(5 < "1");
+    expect(smaller("1", 5)).to.equal("1" < 5);
+    expect(smaller("5", true)).to.equal("5" < true);
+    expect(smaller(5, {})).to.equal(5 < {});
+  });
+
   it("should eval numbers correctly", () => {
     expect(smaller(0, 0)).to.equal(false);
     expect(smaller(-1, -2)).to.equal(false);
@@ -72,7 +80,7 @@ describe("Custom smaller than operator", () => {
     });
 
     it("should return false for unsupported date format", () => {
-      expect(smaller(date3, date4)).to.equal(false);
+      expect(smaller(date3, date4)).to.equal(date3 < date4);
     });
   });
 


### PR DESCRIPTION
- We were returning false for all operators when the types of left and right operands were unequal
- This MR changes that to use default liquidJS handling when operands are of unequal types
- Added tests and verified that they are passing