### PR TITLE
feat and test (create): [SPD-3716] Add currency and duration filters to LiquidJS and test coverage for both filters

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -75,6 +75,8 @@ var filters = {
   strip_html: v => stringify(v).replace(/<\/?\s*\w+\s*\/?>/g, ""),
   strip_newlines: v => stringify(v).replace(/\n/g, ""),
   times: (v, arg) => multiply(v, arg),
+  toCurrency: (v, arg) => toCurrency(v, arg),
+  toDuration: (v, arg) => toDuration(v, arg),
   truncate: (v, l, o) => {
     v = stringify(v);
     o = o === undefined ? "..." : o;
@@ -447,6 +449,41 @@ function operationOnDates(v, arg, operation) {
   }
 }
 
+function toCurrency(currValue, currType) {
+  if (
+    typeof currValue === "number" &&
+    !isNaN(currValue) &&
+    Math.sign(currValue) === 1 &&
+    typeof currType === "string"
+  ) {
+    return { value: currValue, type: currType };
+  }
+  throw new Error("invalid currency value or type");
+}
+
+function toDuration(durValue, durType) {
+  if (
+    typeof durValue === "number" &&
+    !isNaN(durValue) &&
+    typeof durType === "string"
+  ) {
+    let durationType = durType.toLowerCase();
+
+    switch (durationType) {
+      case "days":
+        return { value: durValue, type: durType, days: durValue };
+      case "weeks":
+        return { value: durValue, type: durType, days: durValue * 7 };
+      case "months":
+        return { value: durValue, type: durType, days: durValue * 30 };
+      case "years":
+        return { value: durValue, type: durType, days: durValue * 365 };
+      default:
+        throw new Error("duration type string is incorrect");
+    }
+  }
+  throw new Error("invalid duration value or type");
+}
 
 registerAll.filters = filters;
 module.exports = registerAll;

--- a/filters.js
+++ b/filters.js
@@ -208,11 +208,10 @@ function calculateDurationInDays(toDate, fromDate) {
 /**
  * 
  * @param {number} durValue - should be a number, can be 0, negative number. 
- * Cannot be NaN, undefined, null or other datatypes.
  * @param {string} durType - should be a string and be either days, weeks, months or years. 
  * @returns A number which is a product of durValue and x, where x depends on 
  * durType (days, weeks, months or years). An error will be thrown if x is not
- *  days, weeks, months or years.
+ * days, weeks, months or years.
  */
 function calculateDaysFromDurValueAndType(durValue, durType){
   switch (durType) {

--- a/filters.js
+++ b/filters.js
@@ -19,7 +19,7 @@ var unescapeMap = {
   "&#39;": "'"
 };
 
-const DURATION = {
+const DURATION_TYPES = {
   DAYS: "DAYS", 
   WEEKS: "WEEKS", 
   MONTHS: "MONTHS", 
@@ -205,15 +205,24 @@ function calculateDurationInDays(toDate, fromDate) {
   }
 }
 
+/**
+ * 
+ * @param {number} durValue - should be a number, can be 0, negative number. 
+ * Cannot be NaN, undefined, null or other datatypes.
+ * @param {string} durType - should be a string and be either days, weeks, months or years. 
+ * @returns A number which is a product of durValue and x, where x depends on 
+ * durType (days, weeks, months or years). An error will be thrown if x is not
+ *  days, weeks, months or years.
+ */
 function calculateDaysFromDurValueAndType(durValue, durType){
   switch (durType) {
-    case DURATION.DAYS:
+    case DURATION_TYPES.DAYS:
       return durValue;
-    case DURATION.WEEKS:
+    case DURATION_TYPES.WEEKS:
       return durValue * 7;
-    case DURATION.MONTHS:
+    case DURATION_TYPES.MONTHS:
       return durValue * 30;
-    case DURATION.YEARS:
+    case DURATION_TYPES.YEARS:
       return durValue * 365;
     default:
       throw new Error(
@@ -474,6 +483,13 @@ function operationOnDates(v, arg, operation) {
   }
 }
 
+/**
+ * 
+ * @param {number} currValue - should be a number, can be 0, negative number. 
+ * @param {string} currType - should be a string
+ * @returns An object with properties value(of type number, value same as currValue) 
+ * and type(of type string and value same as currType)
+ */
 function toCurrency(currValue, currType) {
   if (
     isValidNumber(currValue) &&
@@ -484,6 +500,15 @@ function toCurrency(currValue, currType) {
   throw new Error("invalid currency value or type");
 }
 
+
+/**
+ * 
+ * @param {number} durValue - should be a number, can be 0, negative number. 
+ * @param {string} durType - should be a string and be either days, weeks, months or years.
+ * @returns An object with properties value(of type number, value same as durValue), 
+ * type(of type string, value same as durType), 
+ * days(of type number, value calcuated from arguments durValue and durType)
+ */
 function toDuration(durValue, durType) {
   if (
     isValidNumber(durValue) &&
@@ -491,11 +516,13 @@ function toDuration(durValue, durType) {
   ) {
     const durationType = durType.toUpperCase();
 
-    return {
-      value: durValue,
-      type: durationType,
-      days: calculateDaysFromDurValueAndType(durValue, durationType)
-    };
+    if(Object.values(DURATION_TYPES).includes(durationType)){
+      return {
+        value: durValue,
+        type: durationType,
+        days: calculateDaysFromDurValueAndType(durValue, durationType)
+      };
+    }
   }
   throw new Error("invalid duration value or type");
 }

--- a/filters.js
+++ b/filters.js
@@ -19,6 +19,13 @@ var unescapeMap = {
   "&#39;": "'"
 };
 
+const DURATION = {
+  DAYS: "DAYS", 
+  WEEKS: "WEEKS", 
+  MONTHS: "MONTHS", 
+  YEARS: "YEARS"
+}
+
 var filters = {
   abs: v => Math.abs(v),
   append: (v, arg) => v + arg,
@@ -195,6 +202,24 @@ function calculateDurationInDays(toDate, fromDate) {
     type: "DAYS",
     value: durationInDays,
     days: durationInDays
+  }
+}
+
+function calculateDaysFromDurValueAndType(durValue, durType){
+  switch (durType) {
+    case DURATION.DAYS:
+      return durValue;
+    case DURATION.WEEKS:
+      return durValue * 7;
+    case DURATION.MONTHS:
+      return durValue * 30;
+    case DURATION.YEARS:
+      return durValue * 365;
+    default:
+      throw new Error(
+        `duration type found to be incorrect` +
+          `while calculating days from durValue and durType`
+      );
   }
 }
 
@@ -452,7 +477,6 @@ function operationOnDates(v, arg, operation) {
 function toCurrency(currValue, currType) {
   if (
     isValidNumber(currValue) &&
-    Math.sign(currValue) === 1 &&
     _.isString(currType)
   ) {
     return { value: currValue, type: currType };
@@ -463,20 +487,35 @@ function toCurrency(currValue, currType) {
 function toDuration(durValue, durType) {
   if (
     isValidNumber(durValue) &&
-    Math.sign(durValue) === 1 &&
     _.isString(durType)
   ) {
-    let durationType = durType.toLowerCase();
+    const durationTypeInput = durType.toUpperCase();
 
-    switch (durationType) {
-      case "days":
-        return { value: durValue, type: durType.toUpperCase(), days: durValue };
-      case "weeks":
-        return { value: durValue, type: durType.toUpperCase(), days: durValue * 7 };
-      case "months":
-        return { value: durValue, type: durType.toUpperCase(), days: durValue * 30 };
-      case "years":
-        return { value: durValue, type: durType.toUpperCase(), days: durValue * 365 };
+    switch (durationTypeInput) {
+      case DURATION.DAYS:
+        return {
+          value: durValue,
+          type: durType.toUpperCase(),
+          days: calculateDaysFromDurValueAndType(durValue, durationTypeInput)
+        };
+      case DURATION.WEEKS:
+        return {
+          value: durValue,
+          type: durType.toUpperCase(),
+          days: calculateDaysFromDurValueAndType(durValue, durationTypeInput)
+        };
+      case DURATION.MONTHS:
+        return {
+          value: durValue,
+          type: durType.toUpperCase(),
+          days: calculateDaysFromDurValueAndType(durValue, durationTypeInput)
+        };
+      case DURATION.YEARS:
+        return {
+          value: durValue,
+          type: durType.toUpperCase(),
+          days: calculateDaysFromDurValueAndType(durValue, durationTypeInput)
+        };
       default:
         throw new Error("duration type is incorrect");
     }

--- a/filters.js
+++ b/filters.js
@@ -217,7 +217,7 @@ function calculateDaysFromDurValueAndType(durValue, durType){
       return durValue * 365;
     default:
       throw new Error(
-        `duration type found to be incorrect` +
+        `duration type of ${durType} found to be incorrect` +
           `while calculating days from durValue and durType`
       );
   }

--- a/filters.js
+++ b/filters.js
@@ -491,34 +491,11 @@ function toDuration(durValue, durType) {
   ) {
     const durationType = durType.toUpperCase();
 
-    switch (durationType) {
-      case DURATION.DAYS:
-        return {
-          value: durValue,
-          type: durationType,
-          days: calculateDaysFromDurValueAndType(durValue, durationType)
-        };
-      case DURATION.WEEKS:
-        return {
-          value: durValue,
-          type: durationType,
-          days: calculateDaysFromDurValueAndType(durValue, durationType)
-        };
-      case DURATION.MONTHS:
-        return {
-          value: durValue,
-          type: durationType,
-          days: calculateDaysFromDurValueAndType(durValue, durationType)
-        };
-      case DURATION.YEARS:
-        return {
-          value: durValue,
-          type: durationType,
-          days: calculateDaysFromDurValueAndType(durValue, durationType)
-        };
-      default:
-        throw new Error("duration type is incorrect");
-    }
+    return {
+      value: durValue,
+      type: durationType,
+      days: calculateDaysFromDurValueAndType(durValue, durationType)
+    };
   }
   throw new Error("invalid duration value or type");
 }

--- a/filters.js
+++ b/filters.js
@@ -465,19 +465,20 @@ function toDuration(durValue, durType) {
   if (
     typeof durValue === "number" &&
     !isNaN(durValue) &&
+    Math.sign(durValue) === 1 &&
     typeof durType === "string"
   ) {
     let durationType = durType.toLowerCase();
 
     switch (durationType) {
       case "days":
-        return { value: durValue, type: durType, days: durValue };
+        return { value: durValue, type: durType.toUpperCase(), days: durValue };
       case "weeks":
-        return { value: durValue, type: durType, days: durValue * 7 };
+        return { value: durValue, type: durType.toUpperCase(), days: durValue * 7 };
       case "months":
-        return { value: durValue, type: durType, days: durValue * 30 };
+        return { value: durValue, type: durType.toUpperCase(), days: durValue * 30 };
       case "years":
-        return { value: durValue, type: durType, days: durValue * 365 };
+        return { value: durValue, type: durType.toUpperCase(), days: durValue * 365 };
       default:
         throw new Error("duration type string is incorrect");
     }

--- a/filters.js
+++ b/filters.js
@@ -489,32 +489,32 @@ function toDuration(durValue, durType) {
     isValidNumber(durValue) &&
     _.isString(durType)
   ) {
-    const durationTypeUpCase = durType.toUpperCase();
+    const durationType = durType.toUpperCase();
 
-    switch (durationTypeUpCase) {
+    switch (durationType) {
       case DURATION.DAYS:
         return {
           value: durValue,
-          type: durationTypeUpCase,
-          days: calculateDaysFromDurValueAndType(durValue, durationTypeUpCase)
+          type: durationType,
+          days: calculateDaysFromDurValueAndType(durValue, durationType)
         };
       case DURATION.WEEKS:
         return {
           value: durValue,
-          type: durationTypeUpCase,
-          days: calculateDaysFromDurValueAndType(durValue, durationTypeUpCase)
+          type: durationType,
+          days: calculateDaysFromDurValueAndType(durValue, durationType)
         };
       case DURATION.MONTHS:
         return {
           value: durValue,
-          type: durationTypeUpCase,
-          days: calculateDaysFromDurValueAndType(durValue, durationTypeUpCase)
+          type: durationType,
+          days: calculateDaysFromDurValueAndType(durValue, durationType)
         };
       case DURATION.YEARS:
         return {
           value: durValue,
-          type: durationTypeUpCase,
-          days: calculateDaysFromDurValueAndType(durValue, durationTypeUpCase)
+          type: durationType,
+          days: calculateDaysFromDurValueAndType(durValue, durationType)
         };
       default:
         throw new Error("duration type is incorrect");

--- a/filters.js
+++ b/filters.js
@@ -451,10 +451,9 @@ function operationOnDates(v, arg, operation) {
 
 function toCurrency(currValue, currType) {
   if (
-    typeof currValue === "number" &&
-    !isNaN(currValue) &&
+    isValidNumber(currValue) &&
     Math.sign(currValue) === 1 &&
-    typeof currType === "string"
+    _.isString(currType)
   ) {
     return { value: currValue, type: currType };
   }
@@ -463,10 +462,9 @@ function toCurrency(currValue, currType) {
 
 function toDuration(durValue, durType) {
   if (
-    typeof durValue === "number" &&
-    !isNaN(durValue) &&
+    isValidNumber(durValue) &&
     Math.sign(durValue) === 1 &&
-    typeof durType === "string"
+    _.isString(durType)
   ) {
     let durationType = durType.toLowerCase();
 
@@ -480,7 +478,7 @@ function toDuration(durValue, durType) {
       case "years":
         return { value: durValue, type: durType.toUpperCase(), days: durValue * 365 };
       default:
-        throw new Error("duration type string is incorrect");
+        throw new Error("duration type is incorrect");
     }
   }
   throw new Error("invalid duration value or type");

--- a/filters.js
+++ b/filters.js
@@ -489,32 +489,32 @@ function toDuration(durValue, durType) {
     isValidNumber(durValue) &&
     _.isString(durType)
   ) {
-    const durationTypeInput = durType.toUpperCase();
+    const durationTypeUpCase = durType.toUpperCase();
 
-    switch (durationTypeInput) {
+    switch (durationTypeUpCase) {
       case DURATION.DAYS:
         return {
           value: durValue,
-          type: durType.toUpperCase(),
-          days: calculateDaysFromDurValueAndType(durValue, durationTypeInput)
+          type: durationTypeUpCase,
+          days: calculateDaysFromDurValueAndType(durValue, durationTypeUpCase)
         };
       case DURATION.WEEKS:
         return {
           value: durValue,
-          type: durType.toUpperCase(),
-          days: calculateDaysFromDurValueAndType(durValue, durationTypeInput)
+          type: durationTypeUpCase,
+          days: calculateDaysFromDurValueAndType(durValue, durationTypeUpCase)
         };
       case DURATION.MONTHS:
         return {
           value: durValue,
-          type: durType.toUpperCase(),
-          days: calculateDaysFromDurValueAndType(durValue, durationTypeInput)
+          type: durationTypeUpCase,
+          days: calculateDaysFromDurValueAndType(durValue, durationTypeUpCase)
         };
       case DURATION.YEARS:
         return {
           value: durValue,
-          type: durType.toUpperCase(),
-          days: calculateDaysFromDurValueAndType(durValue, durationTypeInput)
+          type: durationTypeUpCase,
+          days: calculateDaysFromDurValueAndType(durValue, durationTypeUpCase)
         };
       default:
         throw new Error("duration type is incorrect");

--- a/test/filters.js
+++ b/test/filters.js
@@ -713,10 +713,10 @@ describe('filters', function () {
     })
   })
 
-  describe("toCurrency", function () {
+  describe("toCurrency", function(){
     let errorMessage = "invalid currency value or type";
 
-    it('should return {value: 8000, type: "INR"} for params 8000 and "INR"', () => {
+    it('should return {value: 8000, type: "INR"}"', () => {
       const dst = { value: 8000, type: "INR" };
       return test('{{ 8000 | toCurrency: "INR" }}', JSON.stringify(dst));
     });
@@ -731,25 +731,62 @@ describe('filters', function () {
       return test('{{ 150.1 | toCurrency: "USD" }}', JSON.stringify(dst));
     });
 
-    it("should throw error for currValue 0", () =>
+    it("should throw error when currency value is 0", () =>
       checkForError('{{ 0 | toCurrency: "USD" }}', errorMessage));
 
-    it("should throw error currValue -100", () =>
+    it("should throw error when currency value is negative number", () =>
       checkForError('{{ -100 | toCurrency: "USD" }}', errorMessage));
 
-    it("should throw error currValue is a string", () =>
+    it("should throw error when currency value is a string", () =>
       checkForError('{{ test | toCurrency: "USD" }}', errorMessage));
 
-    it("should throw error currType a number", () =>
+    it("should throw error when currency type is a number", () =>
       checkForError("{{ 100 | toCurrency: 1 }}", errorMessage));
 
-    it("should throw error currType a symbol", () =>
+    it("should throw error when currency type is a symbol", () =>
       checkForError("{{ 100 | toCurrency: $ }}", errorMessage));
   });
 
-  // describe("toDuration", function(){
-  //   it("should return {value: 5, type: 'MONTHS', days: 150", () => test())
-  // })
+  describe("toDuration", function(){
+
+    const durationTypeErrMsg = "duration type string is incorrect";
+    const invalidDurationTypeOrValueErrMsg = "invalid duration value or type";
+
+    it("should return {value: 10, type: 'DAYS', days: 10}", () => {
+      const dst = {value: 10, type: 'DAYS', days: 10};
+      return test('{{ 10 | toDuration: "Days" }}', JSON.stringify(dst))
+    })
+
+    it("should return {value: 7, type: 'weeks', days: 49}", () => {
+      const dst = {value: 7, type: 'WEEKS', days: 49};
+      return test('{{ 7 | toDuration: "weeks" }}', JSON.stringify(dst))
+    })
+
+    it("should return {value: 5, type: 'MONTHS', days: 150}", () => {
+      const dst = {value: 5, type: 'MONTHS', days: 150};
+      return test('{{ 5 | toDuration: "months" }}', JSON.stringify(dst))
+    })
+
+    it("should return {value: 2, type: 'YEARS', days: 730}", () => {
+      const dst = {value: 2, type: 'YEARS', days: 730};
+      return test('{{ 2 | toDuration: "Years" }}', JSON.stringify(dst))
+    })
+
+    it("should throw error when duration type is not days, weeks, months or years", () =>
+      checkForError('{{ 2 | toDuration: "fortnight" }}', durationTypeErrMsg));
+
+    it("should throw error when duration value is not a number", () =>
+      checkForError('{{ "test" | toDuration: "days" }}', invalidDurationTypeOrValueErrMsg));
+
+    it("should throw error when duration value is NaN", () =>
+      checkForError('{{ NaN | toDuration: "days" }}', invalidDurationTypeOrValueErrMsg));
+
+    it("should throw error when duration value is negative number", () =>
+      checkForError('{{ -10 | toDuration: "days" }}', invalidDurationTypeOrValueErrMsg));
+
+    it("should throw error when duration type is not a string", () =>
+    checkForError('{{ 10 | toDuration: 10 }}', invalidDurationTypeOrValueErrMsg));
+  })
 
   describe('truncate', function () {
     it('should truncate when string too long', function () {

--- a/test/filters.js
+++ b/test/filters.js
@@ -714,7 +714,7 @@ describe('filters', function () {
   })
 
   describe("toCurrency", function(){
-    let errorMessage = "invalid currency value or type";
+    const errorMessage = "invalid currency value or type";
 
     it('should return {value: 8000, type: "INR"}"', () => {
       const dst = { value: 8000, type: "INR" };
@@ -730,12 +730,6 @@ describe('filters', function () {
       const dst = { value: 150.1, type: "USD" };
       return test('{{ 150.1 | toCurrency: "USD" }}', JSON.stringify(dst));
     });
-
-    it("should throw error when currency value is 0", () =>
-      checkForError('{{ 0 | toCurrency: "USD" }}', errorMessage));
-
-    it("should throw error when currency value is negative number", () =>
-      checkForError('{{ -100 | toCurrency: "USD" }}', errorMessage));
 
     it("should throw error when currency value is a string", () =>
       checkForError('{{ test | toCurrency: "USD" }}', errorMessage));
@@ -781,14 +775,11 @@ describe('filters', function () {
     it("should throw error when duration value is NaN", () =>
       checkForError('{{ NaN | toDuration: "days" }}', invalidDurationTypeOrValueErrMsg));
 
-    it("should throw error when duration value is negative number", () =>
-      checkForError('{{ -10 | toDuration: "days" }}', invalidDurationTypeOrValueErrMsg));
-
     it("should throw error when duration type is not a string", () =>
     checkForError('{{ 10 | toDuration: 10 }}', invalidDurationTypeOrValueErrMsg));
 
     it("should throw error when duration value is undefined", () =>
-    checkForError('{{ | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));
+    checkForError('{{ undefined | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));
 
     it("should throw error when duration value is null", () =>
     checkForError('{{ null | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));

--- a/test/filters.js
+++ b/test/filters.js
@@ -52,6 +52,12 @@ function test (src, dst) {
   return expect(liquid.parseAndRender(src, ctx)).to.eventually.equal(dst)
 }
 
+function checkForError(src, errorMessage) {
+  return expect(liquid.parseAndRender(src, ctx)).to.be.rejectedWith(
+    errorMessage
+  );
+}
+
 describe('filters', function () {
   describe('abs', function () {
     it('should return 3 for -3', () => test('{{ -3 | abs }}', '3'))
@@ -706,6 +712,44 @@ describe('filters', function () {
       return test('{{ 2 | times: currency_val_null | times: currency_thousand}}', JSON.stringify(dst))
     })
   })
+
+  describe("toCurrency", function () {
+    let errorMessage = "invalid currency value or type";
+
+    it('should return {value: 8000, type: "INR"} for params 8000 and "INR"', () => {
+      const dst = { value: 8000, type: "INR" };
+      return test('{{ 8000 | toCurrency: "INR" }}', JSON.stringify(dst));
+    });
+
+    it('should return {value: 100, type: "USD"} for params 100 and "USD"', () => {
+      const dst = { value: 100, type: "USD" };
+      return test('{{ 100 | toCurrency: "USD" }}', JSON.stringify(dst));
+    });
+
+    it('should return {value: 100, type: "USD"} for params 100 and "USD"', () => {
+      const dst = { value: 150.1, type: "USD" };
+      return test('{{ 150.1 | toCurrency: "USD" }}', JSON.stringify(dst));
+    });
+
+    it("should throw error for currValue 0", () =>
+      checkForError('{{ 0 | toCurrency: "USD" }}', errorMessage));
+
+    it("should throw error currValue -100", () =>
+      checkForError('{{ -100 | toCurrency: "USD" }}', errorMessage));
+
+    it("should throw error currValue is a string", () =>
+      checkForError('{{ test | toCurrency: "USD" }}', errorMessage));
+
+    it("should throw error currType a number", () =>
+      checkForError("{{ 100 | toCurrency: 1 }}", errorMessage));
+
+    it("should throw error currType a symbol", () =>
+      checkForError("{{ 100 | toCurrency: $ }}", errorMessage));
+  });
+
+  // describe("toDuration", function(){
+  //   it("should return {value: 5, type: 'MONTHS', days: 150", () => test())
+  // })
 
   describe('truncate', function () {
     it('should truncate when string too long', function () {

--- a/test/filters.js
+++ b/test/filters.js
@@ -53,6 +53,11 @@ function test (src, dst) {
 }
 
 function checkForError(src, errorMessage) {
+
+  if(!errorMessage){
+    return expect(liquid.parseAndRender(src, ctx)).to.be.rejected;
+  }
+
   return expect(liquid.parseAndRender(src, ctx)).to.be.rejectedWith(
     errorMessage
   );
@@ -714,31 +719,31 @@ describe('filters', function () {
   })
 
   describe("toCurrency", function(){
-    const errorMessage = "invalid currency value or type";
+    const errMessage = "invalid currency value or type";
 
     it('should return {value: 8000, type: "INR"}"', () => {
       const dst = { value: 8000, type: "INR" };
       return test('{{ 8000 | toCurrency: "INR" }}', JSON.stringify(dst));
     });
 
-    it('should return {value: 100, type: "USD"} for params 100 and "USD"', () => {
+    it('should return {value: 100, type: "USD"}', () => {
       const dst = { value: 100, type: "USD" };
       return test('{{ 100 | toCurrency: "USD" }}', JSON.stringify(dst));
     });
 
-    it('should return {value: 100, type: "USD"} for params 100 and "USD"', () => {
+    it('should return {value: 150.1, type: "USD"}', () => {
       const dst = { value: 150.1, type: "USD" };
       return test('{{ 150.1 | toCurrency: "USD" }}', JSON.stringify(dst));
     });
 
     it("should throw error when currency value is a string", () =>
-      checkForError('{{ test | toCurrency: "USD" }}', errorMessage));
+      checkForError('{{ test | toCurrency: "USD" }}', errMessage));
 
     it("should throw error when currency type is a number", () =>
-      checkForError("{{ 100 | toCurrency: 1 }}", errorMessage));
+      checkForError("{{ 100 | toCurrency: 1 }}", errMessage));
 
     it("should throw error when currency type is a symbol", () =>
-      checkForError("{{ 100 | toCurrency: $ }}", errorMessage));
+      checkForError("{{ 100 | toCurrency: $ }}", errMessage));
   });
 
   describe("toDuration", function(){

--- a/test/filters.js
+++ b/test/filters.js
@@ -736,14 +736,41 @@ describe('filters', function () {
       return test('{{ 150.1 | toCurrency: "USD" }}', JSON.stringify(dst));
     });
 
+    it("should return value and type same as existing variable", () => 
+      test(
+        "{% assign currVar = currency_thousand.value | toCurrency: currency_thousand.type %}{{currVar}}",
+        JSON.stringify(ctx.currency_thousand)
+      )
+    );
+
+    it("should throw error when assigning value from existing variable with null value", () =>
+      checkForError(
+        '{% assign currVar = currency_val_null.value  | toCurrency: currency_val_null.type %}{{currVar}}',
+         errMessage));
+
     it("should throw error when currency value is a string", () =>
       checkForError('{{ test | toCurrency: "USD" }}', errMessage));
+
+    it("should throw error when currency value is null", () =>
+      checkForError('{{ null | toCurrency: "USD" }}', errMessage));
+
+    it("should throw error when currency value is undefined", () =>
+      checkForError('{{ undefined | toCurrency: "USD" }}', errMessage));
+
+    it("should throw error when currency value is NaN", () =>
+      checkForError('{{ NaN | toCurrency: "USD" }}', errMessage));
 
     it("should throw error when currency type is a number", () =>
       checkForError("{{ 100 | toCurrency: 1 }}", errMessage));
 
     it("should throw error when currency type is a symbol", () =>
       checkForError("{{ 100 | toCurrency: $ }}", errMessage));
+
+    it("should throw error when currency type is null", () =>
+      checkForError("{{ 100 | toCurrency: null }}", errMessage));
+
+    it("should throw error when currency type is undefined", () =>
+      checkForError("{{ 100 | toCurrency: undefined }}", errMessage));
   });
 
   describe("toDuration", function(){
@@ -771,29 +798,43 @@ describe('filters', function () {
       return test('{{ 2 | toDuration: "Years" }}', JSON.stringify(dst))
     })
 
-    it("should throw error when duration type is not days, weeks, months or years", () =>
-      checkForError('{{ 2 | toDuration: "fortnight" }}', durationTypeErrMsg));
+    it("should return duration value, type as existing variable with days calculated", () => 
+      test(
+        '{% assign durVar = duration_10_weeks.value | toDuration: duration_10_weeks.type %}{{durVar}}', 
+        JSON.stringify(ctx.duration_10_weeks)
+      )
+    )
 
-    it("should throw error when duration value is not a number", () =>
+    it("should return duration value, type as existing variable with days calculated", () => 
+      test(
+        '{% assign durVar = duration_3_years.value | toDuration: duration_3_years.type %}{{durVar}}', 
+        JSON.stringify(ctx.duration_3_years)
+      )
+    )
+
+    it("should throw error when duration value is a string", () =>
       checkForError('{{ "test" | toDuration: "days" }}', invalidDurationTypeOrValueErrMsg));
 
     it("should throw error when duration value is NaN", () =>
       checkForError('{{ NaN | toDuration: "days" }}', invalidDurationTypeOrValueErrMsg));
 
-    it("should throw error when duration type is not a string", () =>
-    checkForError('{{ 10 | toDuration: 10 }}', invalidDurationTypeOrValueErrMsg));
-
     it("should throw error when duration value is undefined", () =>
-    checkForError('{{ undefined | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));
+      checkForError('{{ undefined | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));
 
     it("should throw error when duration value is null", () =>
-    checkForError('{{ null | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));
+      checkForError('{{ null | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));
+
+    it("should throw error when duration type is not days, weeks, months or years", () =>
+      checkForError('{{ 2 | toDuration: "fortnight" }}', durationTypeErrMsg));
+
+    it("should throw error when duration type is a number", () =>
+      checkForError('{{ 10 | toDuration: 10 }}', invalidDurationTypeOrValueErrMsg));
 
     it("should throw error when duration type is null", () =>
-    checkForError('{{ 10 | toDuration: null }}', invalidDurationTypeOrValueErrMsg));
+      checkForError('{{ 10 | toDuration: null }}', invalidDurationTypeOrValueErrMsg));
 
     it("should throw error when duration type is undefined", () =>
-    checkForError('{{ 10 | toDuration:  }}', invalidDurationTypeOrValueErrMsg));
+      checkForError('{{ 10 | toDuration: undefined }}', invalidDurationTypeOrValueErrMsg));
   })
 
   describe('truncate', function () {

--- a/test/filters.js
+++ b/test/filters.js
@@ -825,9 +825,7 @@ describe('filters', function () {
       checkForError('{{ null | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));
 
     it("should throw error when duration type is not days, weeks, months or years", () =>
-      checkForError('{{ 2 | toDuration: duration_fortnight_invalid.type }}', 
-      `duration type of ${ctx.duration_fortnight_invalid.type} found to be incorrect` +
-      `while calculating days from durValue and durType`));
+      checkForError('{{ 2 | toDuration: duration_fortnight_invalid.type }}', invalidDurationTypeOrValueErrMsg));
 
     it("should throw error when duration type is a number", () =>
       checkForError('{{ 10 | toDuration: 10 }}', invalidDurationTypeOrValueErrMsg));

--- a/test/filters.js
+++ b/test/filters.js
@@ -749,7 +749,7 @@ describe('filters', function () {
 
   describe("toDuration", function(){
 
-    const durationTypeErrMsg = "duration type string is incorrect";
+    const durationTypeErrMsg = "duration type is incorrect";
     const invalidDurationTypeOrValueErrMsg = "invalid duration value or type";
 
     it("should return {value: 10, type: 'DAYS', days: 10}", () => {
@@ -786,6 +786,18 @@ describe('filters', function () {
 
     it("should throw error when duration type is not a string", () =>
     checkForError('{{ 10 | toDuration: 10 }}', invalidDurationTypeOrValueErrMsg));
+
+    it("should throw error when duration value is undefined", () =>
+    checkForError('{{ | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));
+
+    it("should throw error when duration value is null", () =>
+    checkForError('{{ null | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));
+
+    it("should throw error when duration type is null", () =>
+    checkForError('{{ 10 | toDuration: null }}', invalidDurationTypeOrValueErrMsg));
+
+    it("should throw error when duration type is undefined", () =>
+    checkForError('{{ 10 | toDuration:  }}', invalidDurationTypeOrValueErrMsg));
   })
 
   describe('truncate', function () {

--- a/test/filters.js
+++ b/test/filters.js
@@ -25,6 +25,7 @@ var ctx = {
   duration_20_days: {value: 20, type: "DAYS", days: 20},
   duration_2_months: {value: 2, type: "MONTHS", days: 60},
   duration_3_years: {value: 3, type: "YEARS", days: 1095},
+  duration_fortnight_invalid: {value: 1, type: "FORTNIGHT", days: 14},
   currency_thousand: {value: 1000, type: "INR"},
   currency_hundred: {value: 100, type: "INR"},
   currency_ten: {value: 10, type: "INR"},
@@ -775,7 +776,6 @@ describe('filters', function () {
 
   describe("toDuration", function(){
 
-    const durationTypeErrMsg = "duration type is incorrect";
     const invalidDurationTypeOrValueErrMsg = "invalid duration value or type";
 
     it("should return {value: 10, type: 'DAYS', days: 10}", () => {
@@ -825,7 +825,9 @@ describe('filters', function () {
       checkForError('{{ null | toDuration: "months" }}', invalidDurationTypeOrValueErrMsg));
 
     it("should throw error when duration type is not days, weeks, months or years", () =>
-      checkForError('{{ 2 | toDuration: "fortnight" }}', durationTypeErrMsg));
+      checkForError('{{ 2 | toDuration: duration_fortnight_invalid.type }}', 
+      `duration type of ${ctx.duration_fortnight_invalid.type} found to be incorrect` +
+      `while calculating days from durValue and durType`));
 
     it("should throw error when duration type is a number", () =>
       checkForError('{{ 10 | toDuration: 10 }}', invalidDurationTypeOrValueErrMsg));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR is for adding currency and duration filters to SpotDraft's version of LiquidJS

Currently, for making dummy variables work, legal team has to use the parseAssign function which is not simple as they will have to set type and values as a part of this process.

This PR will provide currency and duration filters to make creation of respective dummy variables easier. 

We will cover more variables in future PRs, if required.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here: -->

Closes [SPD-3716](https://spotdraft.atlassian.net/browse/SPD-3716)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

<img width="784" alt="image" src="https://user-images.githubusercontent.com/63851960/205652446-a9d239e3-d37f-4448-9bd2-82ea1e22efa2.png">

