### PR TITLE
[SPD-23149] Add filter that sums the elements of an array, optionally summing the values of a specified key in each object.

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -55,7 +55,7 @@ var filters = {
   last: v => v[v.length - 1],
   lstrip: v => stringify(v).replace(/^\s+/, ""),
   map: (arr, arg) => arr.map(v => v[arg]),
-  sum: (arr, arg) => arr.reduce((acc, v) => acc + (v[arg] ?? v), 0),
+  sumArray: (arr, key, defaultSum) => sumArray(arr, key, defaultSum),
   minus: (v, arg) => subtract(v, arg),
   modulo: bindFixed((v, arg) => v % arg),
   newline_to_br: v => v.replace(/\n/g, "<br />"),
@@ -525,6 +525,42 @@ function toDuration(durValue, durType) {
     }
   }
   throw new Error("invalid duration value or type");
+}
+
+/**
+ * Sums the elements of an array, optionally summing the values of a specified key in each object.
+ *
+ * @param {Array} arr - The array to sum.
+ * @param {string} [key] - The key whose values should be summed (optional).
+ * @param {number} [defaultSum=0] - The default sum to return if the array is empty.
+ * @returns {number|object} The sum of the array elements or the sum of the specified key's values.
+ * @throws {Error} If the input is not an array or if the key is invalid.
+ */
+function sumArray (arr, key, defaultSum = 0) {
+  // Check if input is an array
+  if (!Array.isArray(arr)) {
+    throw new Error('Input is not an array')
+  } else if (arr.length > 0) {
+    if (key === undefined) {
+      // If no key is provided, sum the elements directly
+      return arr.slice(1).reduce((acc, item) => performOperations(acc, item, 'ADD'), arr[0])
+    } else if (_.isString(key)) {
+      // If a key is provided, map the values of that key from the array objects
+      const values = arr.map(item => item[key])
+
+      // Check if the key exists in all objects of the array
+      if (!values.every(isDefinedAndNotNullArg)) {
+        throw new Error("Key doesn't exist in all objects of array")
+      }
+
+      return values.slice(1).reduce((acc, item) => performOperations(acc, item, 'ADD'), values[0])
+    } else {
+      throw new Error('Invalid key for sumArray filter')
+    }
+  }
+
+  // Return the default sum if the array is empty
+  return defaultSum
 }
 
 registerAll.filters = filters;

--- a/filters.js
+++ b/filters.js
@@ -537,30 +537,29 @@ function toDuration(durValue, durType) {
  * @throws {Error} If the input is not an array or if the key is invalid.
  */
 function sumArray (arr, key, defaultSum = 0) {
-  // Check if input is an array
   if (!Array.isArray(arr)) {
+    // Check if input is an array
     throw new Error('Input is not an array')
-  } else if (arr.length > 0) {
-    if (key === undefined) {
-      // If no key is provided, sum the elements directly
-      return arr.slice(1).reduce((acc, item) => performOperations(acc, item, 'ADD'), arr[0])
-    } else if (_.isString(key)) {
-      // If a key is provided, map the values of that key from the array objects
-      const values = arr.map(item => item[key])
-
-      // Check if the key exists in all objects of the array
-      if (!values.every(isDefinedAndNotNullArg)) {
-        throw new Error("Key doesn't exist in all objects of array")
-      }
-
-      return values.slice(1).reduce((acc, item) => performOperations(acc, item, 'ADD'), values[0])
-    } else {
-      throw new Error('Invalid key for sumArray filter')
-    }
   }
 
-  // Return the default sum if the array is empty
-  return defaultSum
+  if (arr.length === 0) {
+    // Return the default sum if the array is empty
+    return defaultSum
+  }
+
+  if (key === undefined) {
+    // If no key is provided, sum the elements directly
+    return arr.reduce((acc, item) => performOperations(acc, item, 'ADD'))
+  }
+
+  if (!_.isString(key)) {
+    // Check if the key is a string
+    throw new Error('Invalid key for sumArray filter')
+  }
+
+  // If a valid key is provided, sum the values of that key from the array objects
+  const values = arr.map(item => item[key])
+  return values.reduce((acc, item) => performOperations(acc, item, 'ADD'))
 }
 
 registerAll.filters = filters;

--- a/filters.js
+++ b/filters.js
@@ -55,6 +55,7 @@ var filters = {
   last: v => v[v.length - 1],
   lstrip: v => stringify(v).replace(/^\s+/, ""),
   map: (arr, arg) => arr.map(v => v[arg]),
+  sum: (arr, arg) => arr.reduce((acc, v) => acc + (v[arg] ?? v), 0),
   minus: (v, arg) => subtract(v, arg),
   modulo: bindFixed((v, arg) => v % arg),
   newline_to_br: v => v.replace(/\n/g, "<br />"),

--- a/test/filters.js
+++ b/test/filters.js
@@ -56,6 +56,7 @@ var ctx = {
   dynamic_table_with_empty: [{cost: 100, quantity: 2}, {cost: 200, quantity: 3}, {}]
 }
 
+// This is to added separately in ctx because we are using existing ctx items as individual items in array
 ctx = {
   ...ctx,
   arr_duration: [ctx.duration_10_weeks, ctx.duration_20_days, ctx.duration_2_months, ctx.duration_3_years],
@@ -690,12 +691,12 @@ describe('filters', function () {
 
     // Dynamic table with null
     it('should handle dynamic table with null', () => {
-      return checkForError('{{ dynamic_table_with_null | sumArray: "cost" }}', "Key doesn't exist in all objects of array")
+      return test('{{ dynamic_table_with_null | sumArray: "cost" }}', '300')
     })
 
     // Dynamic table with empty object
     it('should handle dynamic table with empty object', () => {
-      return checkForError('{{ dynamic_table_with_empty | sumArray: "cost" }}', "Key doesn't exist in all objects of array")
+      return test('{{ dynamic_table_with_empty | sumArray: "cost" }}', '300')
     })
 
     // Dynamic table with duration

--- a/test/filters.js
+++ b/test/filters.js
@@ -610,7 +610,7 @@ describe('filters', function () {
 
     // Numeric arrays
     it('should return "15" for array [1, 2, 3, 4, 5]', () => test('{{ arr_numbers | sumArray }}', '15'))
-    it('should return "11" for array with mixed datatypes [undefined, 1, null, 2, {}, 3, "a", 5, true]', () => test('{{ arr_numbers_with_mixed_datatypes | sumArray }}', '6'))
+    it('should return "6" for array with mixed datatypes [undefined, 1, null, 2, {}, 3, "a", 5, true]', () => test('{{ arr_numbers_with_mixed_datatypes | sumArray }}', '6'))
 
     // Duration arrays
     it('should return total days for duration array', () => {

--- a/test/filters.js
+++ b/test/filters.js
@@ -56,7 +56,7 @@ var ctx = {
   dynamic_table_with_empty: [{cost: 100, quantity: 2}, {cost: 200, quantity: 3}, {}]
 }
 
-// This is to added separately in ctx because we are using existing ctx items as individual items in array
+// This is added separately in ctx because we are using existing ctx items as individual items in array
 ctx = {
   ...ctx,
   arr_duration: [ctx.duration_10_weeks, ctx.duration_20_days, ctx.duration_2_months, ctx.duration_3_years],

--- a/test/filters.js
+++ b/test/filters.js
@@ -46,7 +46,39 @@ var ctx = {
   currency_loop_1: {value: 1000, type: "INR"},
   currency_loop_2: {value: 100, type: "INR"},
   loop_counter: 2,
-  loop_i: 1
+  loop_i: 1,
+  arr_invalid: null,
+  arr_empty: [],
+  arr_numbers: [1, 2, 3, 4, 5],
+  arr_numbers_with_mixed_datatypes: [undefined, 1, null, 2, {}, 3, 'a', 5, true],
+  dynamic_table_with_numbers: [{cost: 100, quantity: 2}, {cost: 200, quantity: 3}, {cost: 300, quantity: 4}],
+  dynamic_table_with_null: [{cost: 100, quantity: 2}, {cost: 200, quantity: 3}, {cost: null, quantity: 4}],
+  dynamic_table_with_empty: [{cost: 100, quantity: 2}, {cost: 200, quantity: 3}, {}]
+}
+
+ctx = {
+  ...ctx,
+  arr_duration: [ctx.duration_10_weeks, ctx.duration_20_days, ctx.duration_2_months, ctx.duration_3_years],
+  arr_duration_with_val_null_1: [ctx.duration_10_weeks, ctx.duration_20_days, ctx.duration_val_null],
+  arr_duration_with_val_null_2: [ctx.duration_10_weeks, ctx.duration_val_null, ctx.duration_20_days],
+  arr_duration_with_val_null_3: [ctx.duration_val_null, ctx.duration_10_weeks, ctx.duration_20_days],
+  arr_duration_with_number_1: [ctx.duration_10_weeks, ctx.duration_20_days, 3],
+  arr_duration_with_number_2: [3, ctx.duration_10_weeks, ctx.duration_20_days],
+  arr_duration_with_null: [ctx.duration_10_weeks, null, ctx.duration_20_days],
+  arr_date_with_duration: [ctx.from_date, ctx.duration_10_weeks, ctx.duration_20_days],
+  arr_two_dates: [ctx.from_date, ctx.duration_10_weeks, ctx.to_date],
+  arr_currency: [ctx.currency_thousand, ctx.currency_hundred, ctx.currency_ten],
+  arr_currency_with_decimal: [ctx.currency_thousand, ctx.currency_decimal, ctx.currency_decimal_2],
+  arr_currency_with_val_null_1: [ctx.currency_thousand, ctx.currency_hundred, ctx.currency_val_null],
+  arr_currency_with_val_null_2: [ctx.currency_thousand, ctx.currency_val_null, ctx.currency_hundred],
+  arr_currency_with_val_null_3: [ctx.currency_val_null, ctx.currency_hundred, ctx.currency_ten],
+  arr_currency_with_number_1: [ctx.currency_thousand, ctx.currency_hundred, 3],
+  arr_currency_with_number_2: [3, ctx.currency_thousand, ctx.currency_hundred],
+  arr_currency_with_null: [ctx.currency_thousand, null, ctx.currency_hundred],
+  dynamic_table_with_duration: [{time: ctx.duration_10_weeks}, {time: ctx.duration_20_days}, {time: ctx.duration_2_months}],
+  dynamic_table_with_duration_with_val_null: [{time: ctx.duration_10_weeks}, {time: ctx.duration_20_days}, {time: ctx.duration_val_null}],
+  dynamic_table_with_currency: [{price: ctx.currency_thousand}, {price: ctx.currency_hundred}, {price: ctx.currency_ten}],
+  dynamic_table_with_currency_with_val_null: [{price: ctx.currency_thousand}, {price: ctx.currency_val_null}, {price: ctx.currency_ten}]
 }
 
 function test (src, dst) {
@@ -562,6 +594,135 @@ describe('filters', function () {
     it('should return {type: "DAYS", value: 0, days: 0};', () => {
       const dst = {type: "DAYS", value: 0, days: 0};
       return test('{{ duration_2_months | plus: duration_val_null }}', JSON.stringify(dst))
+    })
+  })
+
+  describe('sumArray', function () {
+    // Invalid array
+    it('should throw error for invalid array', () => {
+      return checkForError('{{ arr_invalid | sumArray }}', 'Input is not an array')
+    })
+
+    // Empty array
+    it('should return "0" for empty array', () => test('{{ arr_empty | sumArray }}', '0'))
+    it('should return default value for empty array', () => test('{{ arr_empty | sumArray: undefined, 10 }}', '10'))
+
+    // Numeric arrays
+    it('should return "15" for array [1, 2, 3, 4, 5]', () => test('{{ arr_numbers | sumArray }}', '15'))
+    it('should return "11" for array with mixed datatypes [undefined, 1, null, 2, {}, 3, "a", 5, true]', () => test('{{ arr_numbers_with_mixed_datatypes | sumArray }}', '6'))
+
+    // Duration arrays
+    it('should return total days for duration array', () => {
+      const expectedResult = JSON.stringify({'type': 'DAYS', 'value': 1245, 'days': 1245})
+      return test('{{ arr_duration | sumArray: }}', expectedResult)
+    })
+
+    it('should handle duration with val_null at last position', () => {
+      const expectedResult = JSON.stringify({'type': 'DAYS', 'value': 0, 'days': 0})
+      return test('{{ arr_duration_with_val_null_1 | sumArray }}', expectedResult)
+    })
+
+    it('should handle duration with val_null at middle position', () => {
+      const expectedResult = JSON.stringify({'type': 'DAYS', 'value': 20, 'days': 20})
+      return test('{{ arr_duration_with_val_null_2 | sumArray }}', expectedResult)
+    })
+
+    it('should handle duration with val_null at first position', () => {
+      const expectedResult = JSON.stringify({'type': 'DAYS', 'value': 20, 'days': 20})
+      return test('{{ arr_duration_with_val_null_3 | sumArray }}', expectedResult)
+    })
+
+    it('should handle duration with number at different positions', () => {
+      const expectedResult = JSON.stringify({'type': 'DAYS', 'value': 93, 'days': 93})
+      return test('{{ arr_duration_with_number_1 | sumArray }}', expectedResult) &&
+            test('{{ arr_duration_with_number_2 | sumArray }}', expectedResult)
+    })
+
+    it('should handle duration with null', () => {
+      const expectedResult = 'null'
+      return test('{{ arr_duration_with_null | sumArray }}', expectedResult)
+    })
+
+    // Date with duration
+    it('should return date after adding durations to date', () => {
+      const expectedResult = new Date(moment(ctx.from_date).add(90, 'days')).toDateString()
+      return test(`{% assign result = arr_date_with_duration | sumArray %}{{ result | date: "%a %b %d %Y" }}`, expectedResult)
+    })
+
+    it('should handle array with two dates and durations', () => {
+      const expectedResult = 'null'
+      return test('{{ arr_two_dates | sumArray }}', expectedResult)
+    })
+
+    // Currency arrays
+    it('should return total value for currency array', () => {
+      const expectedResult = JSON.stringify({ value: 1110, type: 'INR' })
+      return test('{{ arr_currency | sumArray }}', expectedResult)
+    })
+
+    it('should handle currency with decimal values', () => {
+      const expectedResult = JSON.stringify({ value: 1028.023, type: 'INR' })
+      return test('{{ arr_currency_with_decimal | sumArray }}', expectedResult)
+    })
+
+    it('should handle currency with val_null at different positions', () => {
+      const expectedResult = JSON.stringify({ value: 110, type: 'INR' })
+      return test('{{ arr_currency_with_val_null_1 | sumArray }}', expectedResult) &&
+            test('{{ arr_currency_with_val_null_2 | sumArray }}', expectedResult) &&
+            test('{{ arr_currency_with_val_null_3 | sumArray }}', expectedResult)
+    })
+
+    it('should handle currency with number at different positions', () => {
+      const expectedResult = JSON.stringify({ value: 1103, type: 'INR' })
+      return test('{{ arr_currency_with_number_1 | sumArray }}', expectedResult) &&
+            test('{{ arr_currency_with_number_2 | sumArray }}', expectedResult)
+    })
+
+    it('should handle currency with null', () => {
+      const expectedResult = 'null'
+      return test('{{ arr_currency_with_null | sumArray }}', expectedResult)
+    })
+
+    // Dynamic table with numbers
+    it('should return total cost for dynamic table with numbers', () => {
+      return test('{{ dynamic_table_with_numbers | sumArray: "cost" }}', '600')
+    })
+
+    // Dynamic table with null
+    it('should handle dynamic table with null', () => {
+      return checkForError('{{ dynamic_table_with_null | sumArray: "cost" }}', "Key doesn't exist in all objects of array")
+    })
+
+    // Dynamic table with empty object
+    it('should handle dynamic table with empty object', () => {
+      return checkForError('{{ dynamic_table_with_empty | sumArray: "cost" }}', "Key doesn't exist in all objects of array")
+    })
+
+    // Dynamic table with duration
+    it('should return total duration for dynamic table', () => {
+      const expectedResult = JSON.stringify({'type': 'DAYS', 'value': 150, 'days': 150})
+      return test('{{ dynamic_table_with_duration | sumArray: "time" }}', expectedResult)
+    })
+
+    it('should handle dynamic table with duration and val_null', () => {
+      const expectedResult = JSON.stringify({'type': 'DAYS', 'value': 0, 'days': 0})
+      return test('{{ dynamic_table_with_duration_with_val_null | sumArray: "time" }}', expectedResult)
+    })
+
+    // Dynamic table with currency
+    it('should return total price for dynamic table', () => {
+      const expectedResult = JSON.stringify({ value: 1110, type: 'INR' })
+      return test('{{ dynamic_table_with_currency | sumArray: "price" }}', expectedResult)
+    })
+
+    it('should handle dynamic table with currency and val_null', () => {
+      const expectedResult = JSON.stringify({ value: 1010, type: 'INR' })
+      return test('{{ dynamic_table_with_currency_with_val_null | sumArray: "price" }}', expectedResult)
+    })
+
+    // Dynamic table with invalid column
+    it('should handle dynamic table with invalid column', () => {
+      return checkForError('{{ dynamic_table_with_currency | sumArray: 0 }}', 'Invalid key for sumArray filter')
     })
   })
 


### PR DESCRIPTION
## Description

Added `sumArray` filter: It either take an `array` of `objects` along with a `key` / an `array` of primitive datatypes & return the sum. 
The sum happens using the existing `performOperation` method (which is also used to do `plus`). So, it can handle boxed types (duration/date/currency) as well.
The `sumArray` will also handle errors like not an array or invalid key.

## Related Issue

https://spotdraft.atlassian.net/browse/SPD-23149

## Motivation and Context

This filter will be used to get the sum of all Column values of a Dynamic Table.

## How Has This Been Tested?

Unit Tests
