### PR TITLE
fix: [SPD-30985] remove error for $$answer being undefined in column computation

### DIFF
--- a/tags/computeColumn.js
+++ b/tags/computeColumn.js
@@ -33,9 +33,6 @@ module.exports = function (liquid) {
         try {
           await liquid.renderer.renderTemplates(this.templates, context);
           const finalResult = context.get("$$answer");
-          if (finalResult === undefined) {
-            throw new Error("No value assigned to $$answer");
-          }
           table[i] = { ...row, [this.columnName]: finalResult };
         } catch (err) {
           throw err;

--- a/test/tags/computeColumn.js
+++ b/test/tags/computeColumn.js
@@ -55,7 +55,7 @@ describe("tags/computeColumn", function () {
     });
   });
 
-  it("should throw error if $$answer is not present", function () {
+  it("should not throw error if $$answer is not present", async function () {
     const liquid = Liquid();
 
     const ctx = {
@@ -70,8 +70,6 @@ describe("tags/computeColumn", function () {
                       {% assign col3 = self.col1 | plus: self.col2 | plus: someOtherVariable %}
                        {% assign someOtherVariable = 100%}
                 {% endcomputeColumn %}`;
-    liquid.parseAndRender(src, ctx).catch((error) => {
-      expect(error.message).to.include("No value assigned to $$answer");
-    });
+    await expect(liquid.parseAndRender(src, ctx)).to.be.fulfilled;
   });
 });

--- a/test/tags/computeColumn.js
+++ b/test/tags/computeColumn.js
@@ -55,7 +55,7 @@ describe("tags/computeColumn", function () {
     });
   });
 
-  it("should not throw error if $$answer is not present", async function () {
+  it("should not throw error if $$answer is not present and evaluate it as undefined", async function () {
     const liquid = Liquid();
 
     const ctx = {
@@ -70,6 +70,13 @@ describe("tags/computeColumn", function () {
                       {% assign col3 = self.col1 | plus: self.col2 | plus: someOtherVariable %}
                        {% assign someOtherVariable = 100%}
                 {% endcomputeColumn %}`;
-    await expect(liquid.parseAndRender(src, ctx)).to.be.fulfilled;
+    await expect(liquid.parseAndRender(src, ctx)).to.be.fulfilled
+    expect(ctx).to.deep.equal({
+      dynamicTable: [
+        { col1: 2, col2: 3, col3: undefined },
+        { col1: 1, col2: 4, col3: undefined },
+      ],
+      someOtherVariable: 10,
+    });
   });
 });


### PR DESCRIPTION
## Description

remove the error for $$answer being undefined in column computation
remove the test for the same 


## Related Issue
SPD-30985


## Motivation and Context
once we started running dynamic table column computation in CFX, lot more issues pop up
because of $$answer being undefined. we are removing that validation all together to prevent further errors
 
 
## How Has This Been Tested?
- updated test

<img width="549" alt="image" src="https://github.com/user-attachments/assets/aa11d292-702c-4e8e-a2c5-ab80a02b1fa9" />
